### PR TITLE
Properly load imported modules into the globals dict

### DIFF
--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -264,7 +264,7 @@ class ModuleGenerator:
         # This is separate from the *global* reference to the module that will
         # be populated when it is imported by a compiled module. We want that
         # reference to only be populated when the module has been succesfully
-        # imported, whereas this we want to have stop a circular import.
+        # imported, whereas this we want to have to stop a circular import.
         module_static = self.module_internal_static_name(module_name, emitter)
 
         emitter.emit_lines('if ({}) {{'.format(module_static),

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -265,8 +265,7 @@ class ModuleGenerator:
         # be populated when it is imported by a compiled module. We want that
         # reference to only be populated when the module has been succesfully
         # imported, whereas this we want to have stop a circular import.
-        module_static = 'this_module'
-        emitter.emit_lines('static PyObject *{};'.format(module_static))
+        module_static = self.module_internal_static_name(module_name, emitter)
 
         emitter.emit_lines('if ({}) {{'.format(module_static),
                            'Py_INCREF({});'.format(module_static),
@@ -361,11 +360,17 @@ class ModuleGenerator:
         static_name = emitter.static_name('globals', module_name)
         self.declare_global('PyObject *', static_name)
 
-    def module_static_name(self, module_name: str, emitter: Emitter) -> str:
-        return emitter.static_name('module', module_name)
+    def module_internal_static_name(self, module_name: str, emitter: Emitter) -> str:
+        return emitter.static_name('module_internal', module_name)
 
     def declare_module(self, module_name: str, emitter: Emitter) -> None:
-        static_name = self.module_static_name(module_name, emitter)
+        # We declare two globals for each module:
+        # one used internally in the implementation of module init to cache results
+        # and prevent infinite recursion in import cycles, and one used
+        # by other modules to refer to it.
+        internal_static_name = self.module_internal_static_name(module_name, emitter)
+        self.declare_global('CPyModule *', internal_static_name, initializer='NULL')
+        static_name = emitter.static_name('module', module_name)
         self.declare_global('CPyModule *', static_name, initializer='Py_None')
 
     def declare_imports(self, imps: Iterable[str], emitter: Emitter) -> None:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -265,7 +265,7 @@ class ModuleGenerator:
         # be populated when it is imported by a compiled module. We want that
         # reference to only be populated when the module has been succesfully
         # imported, whereas this we want to have stop a circular import.
-        module_static = 'module'
+        module_static = 'this_module'
         emitter.emit_lines('static PyObject *{};'.format(module_static))
 
         emitter.emit_lines('if ({}) {{'.format(module_static),

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -260,8 +260,15 @@ class ModuleGenerator:
             declaration = 'PyObject *CPyInit_{}(void)'.format(exported_name(module_name))
         emitter.emit_lines(declaration,
                            '{')
-        module_static = self.module_static_name(module_name, emitter)
-        emitter.emit_lines('if ({} != Py_None) {{'.format(module_static),
+        # Store the module reference in a static and return it when necessary.
+        # This is separate from the *global* reference to the module that will
+        # be populated when it is imported by a compiled module. We want that
+        # reference to only be populated when the module has been succesfully
+        # imported, whereas this we want to have stop a circular import.
+        module_static = 'module'
+        emitter.emit_lines('static PyObject *{};'.format(module_static))
+
+        emitter.emit_lines('if ({}) {{'.format(module_static),
                            'Py_INCREF({});'.format(module_static),
                            'return {};'.format(module_static),
                            '}')

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -82,7 +82,8 @@ from mypyc.ops_misc import (
     py_getattr_op, py_setattr_op, py_delattr_op,
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
     fast_isinstance_op, bool_op, new_slice_op,
-    type_op, pytype_from_template_op, import_op, ellipsis_op, method_new_op, type_is_op,
+    type_op, pytype_from_template_op, import_op, get_module_dict_op,
+    ellipsis_op, method_new_op, type_is_op,
 )
 from mypyc.ops_exc import (
     no_err_occurred_op, raise_exception_op, raise_exception_with_tb_op, reraise_exception_op,
@@ -970,8 +971,32 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def visit_import(self, node: Import) -> None:
         if node.is_mypy_only:
             return
-        for node_id, _ in node.ids:
+        globals = self.load_globals_dict()
+        for node_id, as_name in node.ids:
             self.gen_import(node_id, node.line)
+
+            # Update the globals dict with the appropriate module:
+            # * For 'import foo.bar as baz' we add 'foo.bar' with the name 'baz'
+            # * For 'import foo.bar' we add 'foo' with the name 'foo'
+            # Typically we then ignore these entries and access things directly
+            # via the module static, but we will use the globals version for modules
+            # that mypy couldn't find, since it doesn't analyze module references
+            # from those properly.
+
+            # Miscompiling imports inside of functions, like below in import from.
+            if as_name:
+                name = as_name
+                base = node_id
+            else:
+                base = name = node_id.split('.')[0]
+
+            # Python 3.7 has a nice 'PyImport_GetModule' function that we can't use :(
+            mod_dict = self.primitive_op(get_module_dict_op, [], node.line)
+            obj = self.primitive_op(dict_get_item_op,
+                                    [mod_dict, self.load_static_unicode(base)], node.line)
+            self.translate_special_method_call(
+                globals, '__setitem__', [self.load_static_unicode(name), obj],
+                result_type=None, line=node.line)
 
     def visit_import_from(self, node: ImportFrom) -> None:
         if node.is_mypy_only:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -958,17 +958,13 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def _gen_import(self, id: str, line: int) -> None:
         self.imports.append(id)
 
-        # Always do the import (to match python semantics, and to
-        # ensure that the module is in sys.modules), but only init the
-        # static if it was uninitialized.
-        value = self.primitive_op(import_op, [self.load_static_unicode(id)], line)
-
-        needs_init, out = BasicBlock(), BasicBlock()
+        needs_import, out = BasicBlock(), BasicBlock()
         first_load = self.add(LoadStatic(object_rprimitive, 'module', id))
         comparison = self.binary_op(first_load, self.none_object(), 'is not', line)
-        self.add_bool_branch(comparison, out, needs_init)
+        self.add_bool_branch(comparison, out, needs_import)
 
-        self.activate_block(needs_init)
+        self.activate_block(needs_import)
+        value = self.primitive_op(import_op, [self.load_static_unicode(id)], line)
         self.add(InitStatic(value, 'module', id))
         self.goto_and_activate(out)
 

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -5,7 +5,7 @@ from typing import List
 from mypyc.ops import (
     EmitterInterface, PrimitiveOp,
     none_rprimitive, bool_rprimitive, object_rprimitive, tuple_rprimitive, str_rprimitive,
-    int_rprimitive,
+    int_rprimitive, dict_rprimitive,
     ERR_NEVER, ERR_MAGIC, ERR_FALSE
 )
 from mypyc.ops_primitive import (
@@ -266,6 +266,15 @@ import_op = custom_op(
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
     emit=call_emit('PyImport_Import'))
+
+
+get_module_dict_op = custom_op(
+    name='get_module_dict',
+    arg_types=[],
+    result_type=dict_rprimitive,
+    error_kind=ERR_NEVER,
+    emit=call_emit('PyImport_GetModuleDict'),
+    is_borrowed=True)
 
 
 func_op('builtins.isinstance',

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -79,6 +79,10 @@ class TestRun(MypycDataSuite):
             options.python_version = (3, 6)
             options.export_types = True
 
+            # Avoid checking modules/packages named 'unchecked', to provide a way
+            # to test interacting with code we don't have types for.
+            options.per_module_options['unchecked.*'] = {'follow_imports': 'error'}
+
             workdir = 'build'
             os.mkdir(workdir)
 

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2800,7 +2800,7 @@ def __top_level__():
     r13 :: object
     r14 :: str
     r15 :: bool
-    r16 :: object
+    r16 :: dict
     r17 :: str
     r18 :: object
     r19 :: dict
@@ -2838,9 +2838,9 @@ L4:
     r13 = getattr r10, r12
     r14 = unicode_2 :: static  ('Callable')
     r15 = r11.__setitem__(r14, r13) :: dict
-    r16 = __main__.module :: static
+    r16 = __main__.globals :: static
     r17 = unicode_11 :: static  ('__mypyc_c_decorator_helper__')
-    r18 = getattr r16, r17
+    r18 = r16[r17] :: dict
     r19 = __main__.globals :: static
     r20 = unicode_8 :: static  ('b')
     r21 = r19[r20] :: dict

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -8,8 +8,10 @@ def f(x: int) -> int:
 #include <Python.h>
 #include <CPy.h>
 
+static CPyModule *CPyStatic_module_internal = NULL;
 static CPyModule *CPyStatic_module = Py_None;
 static PyObject *CPyStatic_globals;
+static CPyModule *CPyStatic_builtins_module_internal = NULL;
 static CPyModule *CPyStatic_builtins_module = Py_None;
 static PyObject *CPyStatic_unicode_0;
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
@@ -43,16 +45,15 @@ static struct PyModuleDef module = {
 
 PyMODINIT_FUNC PyInit_prog(void)
 {
-    static PyObject *this_module;
-    if (this_module) {
-        Py_INCREF(this_module);
-        return this_module;
+    if (CPyStatic_module_internal) {
+        Py_INCREF(CPyStatic_module_internal);
+        return CPyStatic_module_internal;
     }
-    this_module = PyModule_Create(&module);
-    if (unlikely(this_module == NULL))
+    CPyStatic_module_internal = PyModule_Create(&module);
+    if (unlikely(CPyStatic_module_internal == NULL))
         return NULL;
-    PyObject *modname = PyObject_GetAttrString((PyObject *)this_module, "__name__");
-    CPyStatic_globals = PyModule_GetDict(this_module);
+    PyObject *modname = PyObject_GetAttrString((PyObject *)CPyStatic_module_internal, "__name__");
+    CPyStatic_globals = PyModule_GetDict(CPyStatic_module_internal);
     if (unlikely(CPyStatic_globals == NULL))
         return NULL;
     if (CPyLiteralsInit() < 0)
@@ -61,7 +62,7 @@ PyMODINIT_FUNC PyInit_prog(void)
     if (result == 2)
         return NULL;
     Py_DECREF(modname);
-    return this_module;
+    return CPyStatic_module_internal;
 }
 
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x) {

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -43,15 +43,16 @@ static struct PyModuleDef module = {
 
 PyMODINIT_FUNC PyInit_prog(void)
 {
-    if (CPyStatic_module != Py_None) {
-        Py_INCREF(CPyStatic_module);
-        return CPyStatic_module;
+    static PyObject *this_module;
+    if (this_module) {
+        Py_INCREF(this_module);
+        return this_module;
     }
-    CPyStatic_module = PyModule_Create(&module);
-    if (unlikely(CPyStatic_module == NULL))
+    this_module = PyModule_Create(&module);
+    if (unlikely(this_module == NULL))
         return NULL;
-    PyObject *modname = PyObject_GetAttrString((PyObject *)CPyStatic_module, "__name__");
-    CPyStatic_globals = PyModule_GetDict(CPyStatic_module);
+    PyObject *modname = PyObject_GetAttrString((PyObject *)this_module, "__name__");
+    CPyStatic_globals = PyModule_GetDict(this_module);
     if (unlikely(CPyStatic_globals == NULL))
         return NULL;
     if (CPyLiteralsInit() < 0)
@@ -60,7 +61,7 @@ PyMODINIT_FUNC PyInit_prog(void)
     if (result == 2)
         return NULL;
     Py_DECREF(modname);
-    return CPyStatic_module;
+    return this_module;
 }
 
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x) {

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -637,11 +637,16 @@ f(5)
 5
 
 [case testImportMissing]
-# pytest doesn't have stubs but it is obviously installed...
-import pytest  # type: ignore
-import pytest as lol  # type: ignore
-assert pytest.__name__ == 'pytest'
-assert lol.__name__ == 'pytest'
+# The unchecked module is configured by the test harness to not be
+# picked up by mypy, so we can test that we do that right thing when
+# calling library modules without stubs.
+import unchecked  # type: ignore
+import unchecked as lol  # type: ignore
+assert unchecked.x == 10
+assert lol.x == 10
+[file unchecked.py]
+x = 10
+
 [file driver.py]
 import native
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -636,6 +636,15 @@ f(5)
 [out]
 5
 
+[case testImportMissing]
+# pytest doesn't have stubs but it is obviously installed...
+import pytest  # type: ignore
+import pytest as lol  # type: ignore
+assert pytest.__name__ == 'pytest'
+assert lol.__name__ == 'pytest'
+[file driver.py]
+import native
+
 [case testOptional]
 from typing import Optional
 


### PR DESCRIPTION
This fixes access to modules that lack stubs (since mypy
does not analyze access to them as module refs), which fixes
a problem in compiled mypy where `dmypy status` would fail if
`psutil` *was* installed.