### PR TITLE
Don't include trailing whitespace in prim op strings

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -914,7 +914,7 @@ class PrimitiveOp(RegisterOp):
         args = [env.format('%r', arg) for arg in self.args]
         params['args'] = args
         params['comma_args'] = ', '.join(args)
-        return self.desc.format_str.format(**params)
+        return self.desc.format_str.format(**params).strip()
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_primitive_op(self)


### PR DESCRIPTION
I'm not going to update existing tests right now, to avoid
churn and merge conflicts.