### PR TITLE
Support platform checks better and condition function definition

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1263,6 +1263,7 @@ class RaiseStandardError(RegisterOp):
     ASSERTION_ERROR = 'AssertionError'
     STOP_ITERATION = 'StopIteration'
     UNBOUND_LOCAL_ERROR = 'UnboundLocalError'
+    RUNTIME_ERROR = 'RuntimeError'
 
     def __init__(self, class_name: str, value: Optional[Union[str, Value]], line: int) -> None:
         super().__init__(line)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -76,7 +76,9 @@ class TestRun(MypycDataSuite):
             options.use_builtins_fixtures = True
             options.show_traceback = True
             options.strict_optional = True
-            options.python_version = (3, 6)
+            # N.B: We explicitly check with the current version of python, since we are
+            # going to link and run against the current version of python.
+            options.python_version = sys.version_info[:2]
             options.export_types = True
 
             # Avoid checking modules/packages named 'unchecked', to provide a way

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -76,9 +76,11 @@ class TestRun(MypycDataSuite):
             options.use_builtins_fixtures = True
             options.show_traceback = True
             options.strict_optional = True
-            # N.B: We explicitly check with the current version of python, since we are
-            # going to link and run against the current version of python.
-            options.python_version = sys.version_info[:2]
+            # N.B: We try to (and ought to!) run with the current
+            # version of python, since we are going to link and run
+            # against the current version of python.
+            # But a lot of the tests use type annotations so we can't say it is 3.5.
+            options.python_version = max(sys.version_info[:2], (3, 6))
             options.export_types = True
 
             # Avoid checking modules/packages named 'unchecked', to provide a way

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3535,3 +3535,24 @@ print(z)
 (1, 2)
 1
 2
+
+[case testCheckVersion]
+import sys
+
+if sys.version_info[:2] == (3, 7):
+    def version() -> int:
+        return 7
+elif sys.version_info[:2] == (3, 6):
+    def version() -> int:
+        return 6
+elif sys.version_info[:2] == (3, 5):
+    def version() -> int:
+        return 5
+else:
+    raise Exception("we don't support this version yet!")
+
+
+[file driver.py]
+import sys
+import native
+assert native.version() == sys.version_info[1]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3539,20 +3539,25 @@ print(z)
 [case testCheckVersion]
 import sys
 
+# We lie about the version we are running in tests if it is 3.5, so
+# that hits a crash case.
 if sys.version_info[:2] == (3, 7):
     def version() -> int:
         return 7
 elif sys.version_info[:2] == (3, 6):
     def version() -> int:
         return 6
-elif sys.version_info[:2] == (3, 5):
-    def version() -> int:
-        return 5
 else:
     raise Exception("we don't support this version yet!")
 
 
 [file driver.py]
 import sys
-import native
-assert native.version() == sys.version_info[1]
+version = sys.version_info[:2]
+
+try:
+    import native
+    assert version != (3, 5), "3.5 should fail!"
+    assert native.version() == sys.version_info[1]
+except RuntimeError:
+    assert version == (3, 5), "only 3.5 should fail!"


### PR DESCRIPTION
Instead of trying to compile the non-semantically analyzed unreachable
blocks produced by platform and version checks, instead just generate
a RuntimeError from any unreachable block we find.

Additionally, drive the creation of `FuncDecl`s from the module symbol
table instead of the body, so we can pick up conditionally defined
functions more easily.