### PR TITLE
Include the class name in some derived name calculations

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -461,12 +461,14 @@ class FuncInfo(object):
     def __init__(self,
                  fitem: FuncItem = INVALID_FUNC_DEF,
                  name: str = '',
+                 class_name: Optional[str] = None,
                  namespace: str = '',
                  is_nested: bool = False,
                  contains_nested: bool = False,
                  is_decorated: bool = False) -> None:
         self.fitem = fitem
         self.name = name if not is_decorated else decorator_helper_name(name)
+        self.class_name = class_name
         self.ns = namespace
         # Callable classes implement the '__call__' method, and are used to represent functions
         # that are nested inside of other functions.
@@ -489,6 +491,9 @@ class FuncInfo(object):
         self.is_decorated = is_decorated
 
         # TODO: add field for ret_type: RType = none_rprimitive
+
+    def namespaced_name(self) -> str:
+        return '_'.join(x for x in [self.name, self.class_name, self.ns] if x)
 
     @property
     def is_generator(self) -> bool:
@@ -1208,7 +1213,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         is_nested = fitem in self.nested_fitems
         contains_nested = fitem in self.encapsulating_fitems
         is_decorated = fitem in self.fdefs_to_decorators
-        self.enter(FuncInfo(fitem, name, self.gen_func_ns(),
+        self.enter(FuncInfo(fitem, name, class_name, self.gen_func_ns(),
                             is_nested, contains_nested, is_decorated))
 
         if self.fn_info.is_nested:
@@ -3752,8 +3757,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def gen_func_ns(self) -> str:
         """Generates a namespace for a nested function using its outer function names."""
-        return '_'.join(env.name for env in self.environments
-                        if env.name and env.name != '<top level>')
+        return '_'.join(info.name + ('' if not info.class_name else '_' + info.class_name)
+                        for info in self.fn_infos
+                        if info.name and info.name != '<top level>')
 
     def setup_callable_class(self) -> None:
         """Generates a callable class representing a nested function and sets up the 'self'
@@ -3777,10 +3783,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         #     else:
         #         def foo():          ---->    foo_obj_0()
         #             return False
-        name = '{}_{}_obj'.format(self.fn_info.name, self.fn_info.ns)
+        name = base_name = '{}_obj'.format(self.fn_info.namespaced_name())
         count = 0
         while name in self.callable_class_names:
-            name += '_' + str(count)
+            name = base_name + '_' + str(count)
+            count += 1
         self.callable_class_names.add(name)
 
         # Define the actual callable class ClassIR, and set its environment to point at the
@@ -3886,7 +3893,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         Returns a ClassIR representing an environment for a function containing a nested function.
         """
-        env_class = ClassIR('{}_{}_env'.format(self.fn_info.name, self.fn_info.ns),
+        env_class = ClassIR('{}_env'.format(self.fn_info.namespaced_name()),
                             self.module_name, is_generated=True)
         env_class.attributes[SELF_NAME] = RInstance(env_class)
         if self.fn_info.is_nested:
@@ -3934,7 +3941,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.add(Return(self.instantiate_generator_class()))
 
     def setup_generator_class(self) -> ClassIR:
-        name = '{}_{}_gen'.format(self.fn_info.name, self.fn_info.ns)
+        name = '{}_gen'.format(self.fn_info.namespaced_name())
 
         generator_class_ir = ClassIR(name, self.module_name, is_generated=True)
         generator_class_ir.attributes[ENV_ATTR_NAME] = RInstance(self.fn_info.env_class)

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2596,7 +2596,7 @@ L2:
     return r2
 def g_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: g_a_obj
-    r0 :: a__env
+    r0 :: a_env
     r1, g :: object
     r2 :: str
     r3 :: object
@@ -2633,13 +2633,13 @@ L0:
     return r17
 def a(f):
     f :: object
-    r0 :: a__env
+    r0 :: a_env
     r1 :: bool
     r2 :: g_a_obj
     r3, r4 :: bool
     r5 :: object
 L0:
-    r0 = a__env()
+    r0 = a_env()
     r0.f = f; r1 = is_error
     r2 = g_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
@@ -2661,7 +2661,7 @@ L2:
     return r2
 def g_b_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: g_b_obj
-    r0 :: b__env
+    r0 :: b_env
     r1, g :: object
     r2 :: str
     r3 :: object
@@ -2698,13 +2698,13 @@ L0:
     return r17
 def b(f):
     f :: object
-    r0 :: b__env
+    r0 :: b_env
     r1 :: bool
     r2 :: g_b_obj
     r3, r4 :: bool
     r5 :: object
 L0:
-    r0 = b__env()
+    r0 = b_env()
     r0.f = f; r1 = is_error
     r2 = g_b_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
@@ -2726,7 +2726,7 @@ L2:
     return r2
 def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__call__(__mypyc_self__):
     __mypyc_self__ :: __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj
-    r0 :: __mypyc_c_decorator_helper____env
+    r0 :: __mypyc_c_decorator_helper___env
     r1, d :: object
     r2 :: str
     r3 :: object
@@ -2746,7 +2746,7 @@ L0:
     r8 = None
     return r8
 def __mypyc_c_decorator_helper__():
-    r0 :: __mypyc_c_decorator_helper____env
+    r0 :: __mypyc_c_decorator_helper___env
     r1 :: __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj
     r2 :: bool
     r3 :: dict
@@ -2764,7 +2764,7 @@ def __mypyc_c_decorator_helper__():
     r18, r19 :: object
     r20, r21 :: None
 L0:
-    r0 = __mypyc_c_decorator_helper____env()
+    r0 = __mypyc_c_decorator_helper___env()
     r1 = __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = __main__.globals :: static
@@ -2881,7 +2881,7 @@ L2:
     return r2
 def g_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: g_a_obj
-    r0 :: a__env
+    r0 :: a_env
     r1, g :: object
     r2 :: str
     r3 :: object
@@ -2918,13 +2918,13 @@ L0:
     return r17
 def a(f):
     f :: object
-    r0 :: a__env
+    r0 :: a_env
     r1 :: bool
     r2 :: g_a_obj
     r3, r4 :: bool
     r5 :: object
 L0:
-    r0 = a__env()
+    r0 = a_env()
     r0.f = f; r1 = is_error
     r2 = g_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error

--- a/test-data/genops-generators.test
+++ b/test-data/genops-generators.test
@@ -6,10 +6,10 @@ def yield_three_times() -> Iterable:
     yield 2
 
 [out]
-def yield_three_times__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_three_times__gen
+def yield_three_times_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_three_times_gen
     type, value, traceback :: object
-    r0 :: yield_three_times__env
+    r0 :: yield_three_times_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -100,19 +100,19 @@ L15:
 L16:
     raise StopIteration
     unreachable
-def yield_three_times__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_three_times__gen
+def yield_three_times_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_three_times_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_three_times__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_three_times_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_three_times__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_three_times__gen
+def yield_three_times_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_three_times_gen
 L0:
     return __mypyc_self__
-def yield_three_times__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_three_times__gen
+def yield_three_times_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_three_times_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -124,17 +124,17 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_three_times__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_three_times_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_three_times():
-    r0 :: yield_three_times__env
-    r1 :: yield_three_times__gen
+    r0 :: yield_three_times_env
+    r1 :: yield_three_times_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_three_times__env()
-    r1 = yield_three_times__gen()
+    r0 = yield_three_times_env()
+    r1 = yield_three_times_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
@@ -150,10 +150,10 @@ def yield_while_loop() -> Generator:
         i += 1
 
 [out]
-def yield_while_loop__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_while_loop__gen
+def yield_while_loop_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_while_loop_gen
     type, value, traceback :: object
-    r0 :: yield_while_loop__env
+    r0 :: yield_while_loop_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -242,19 +242,19 @@ L13:
 L14:
     raise StopIteration
     unreachable
-def yield_while_loop__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_while_loop__gen
+def yield_while_loop_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_while_loop_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_while_loop__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_while_loop_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_while_loop__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_while_loop__gen
+def yield_while_loop_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_while_loop_gen
 L0:
     return __mypyc_self__
-def yield_while_loop__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_while_loop__gen
+def yield_while_loop_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_while_loop_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -266,17 +266,17 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_while_loop__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_while_loop_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_while_loop():
-    r0 :: yield_while_loop__env
-    r1 :: yield_while_loop__gen
+    r0 :: yield_while_loop_env
+    r1 :: yield_while_loop_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_while_loop__env()
-    r1 = yield_while_loop__gen()
+    r0 = yield_while_loop_env()
+    r1 = yield_while_loop_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
@@ -300,10 +300,10 @@ def yield_for_loop_range() -> Iterable:
         yield i
 
 [out]
-def yield_for_loop_list__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_list__gen
+def yield_for_loop_list_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_list_gen
     type, value, traceback :: object
-    r0 :: yield_for_loop_list__env
+    r0 :: yield_for_loop_list_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -415,19 +415,19 @@ L14:
 L15:
     raise StopIteration
     unreachable
-def yield_for_loop_list__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_list__gen
+def yield_for_loop_list_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_list_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_for_loop_list__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_for_loop_list_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_for_loop_list__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_list__gen
+def yield_for_loop_list_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_list_gen
 L0:
     return __mypyc_self__
-def yield_for_loop_list__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_list__gen
+def yield_for_loop_list_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_list_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -439,25 +439,25 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_for_loop_list__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_for_loop_list_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_for_loop_list():
-    r0 :: yield_for_loop_list__env
-    r1 :: yield_for_loop_list__gen
+    r0 :: yield_for_loop_list_env
+    r1 :: yield_for_loop_list_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_for_loop_list__env()
-    r1 = yield_for_loop_list__gen()
+    r0 = yield_for_loop_list_env()
+    r1 = yield_for_loop_list_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
     return r1
-def yield_for_loop_dict__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_dict__gen
+def yield_for_loop_dict_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_dict_gen
     type, value, traceback :: object
-    r0 :: yield_for_loop_dict__env
+    r0 :: yield_for_loop_dict_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -581,19 +581,19 @@ L19:
 L20:
     raise StopIteration
     unreachable
-def yield_for_loop_dict__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_dict__gen
+def yield_for_loop_dict_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_dict_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_for_loop_dict__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_for_loop_dict_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_for_loop_dict__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_dict__gen
+def yield_for_loop_dict_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_dict_gen
 L0:
     return __mypyc_self__
-def yield_for_loop_dict__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_dict__gen
+def yield_for_loop_dict_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_dict_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -605,25 +605,25 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_for_loop_dict__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_for_loop_dict_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_for_loop_dict():
-    r0 :: yield_for_loop_dict__env
-    r1 :: yield_for_loop_dict__gen
+    r0 :: yield_for_loop_dict_env
+    r1 :: yield_for_loop_dict_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_for_loop_dict__env()
-    r1 = yield_for_loop_dict__gen()
+    r0 = yield_for_loop_dict_env()
+    r1 = yield_for_loop_dict_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
     return r1
-def yield_for_loop_range__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_range__gen
+def yield_for_loop_range_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_range_gen
     type, value, traceback :: object
-    r0 :: yield_for_loop_range__env
+    r0 :: yield_for_loop_range_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -712,19 +712,19 @@ L14:
 L15:
     raise StopIteration
     unreachable
-def yield_for_loop_range__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_range__gen
+def yield_for_loop_range_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_range_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_for_loop_range__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_for_loop_range_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_for_loop_range__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_for_loop_range__gen
+def yield_for_loop_range_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_for_loop_range_gen
 L0:
     return __mypyc_self__
-def yield_for_loop_range__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_for_loop_range__gen
+def yield_for_loop_range_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_for_loop_range_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -736,17 +736,17 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_for_loop_range__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_for_loop_range_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_for_loop_range():
-    r0 :: yield_for_loop_range__env
-    r1 :: yield_for_loop_range__gen
+    r0 :: yield_for_loop_range_env
+    r1 :: yield_for_loop_range_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_for_loop_range__env()
-    r1 = yield_for_loop_range__gen()
+    r0 = yield_for_loop_range_env()
+    r1 = yield_for_loop_range_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
@@ -763,10 +763,10 @@ def yield_with_vars(a: int, b: float) -> Generator[int, None, float]:
     return b
 
 [out]
-def yield_with_vars__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_with_vars__gen
+def yield_with_vars_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_with_vars_gen
     type, value, traceback :: object
-    r0 :: yield_with_vars__env
+    r0 :: yield_with_vars_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -850,19 +850,19 @@ L13:
 L14:
     raise StopIteration
     unreachable
-def yield_with_vars__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_with_vars__gen
+def yield_with_vars_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_with_vars_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_with_vars__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_with_vars_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_with_vars__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_with_vars__gen
+def yield_with_vars_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_with_vars_gen
 L0:
     return __mypyc_self__
-def yield_with_vars__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_with_vars__gen
+def yield_with_vars_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_with_vars_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -874,22 +874,22 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_with_vars__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_with_vars_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_with_vars(a, b):
     a :: int
     b :: float
-    r0 :: yield_with_vars__env
+    r0 :: yield_with_vars_env
     r1, r2 :: bool
-    r3 :: yield_with_vars__gen
+    r3 :: yield_with_vars_gen
     r4 :: bool
     r5 :: short_int
     r6 :: bool
 L0:
-    r0 = yield_with_vars__env()
+    r0 = yield_with_vars_env()
     r0.a = a; r1 = is_error
     r0.b = b; r2 = is_error
-    r3 = yield_with_vars__gen()
+    r3 = yield_with_vars_gen()
     r3.__mypyc_env__ = r0; r4 = is_error
     r5 = 0
     r0.__mypyc_next_label__ = r5; r6 = is_error
@@ -903,10 +903,10 @@ class A(object):
         yield 0
 
 [out]
-def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_A_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_A_gen
     type, value, traceback :: object
-    r0 :: generator__env
+    r0 :: generator_A_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -969,19 +969,19 @@ L10:
 L11:
     raise StopIteration
     unreachable
-def generator__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_A_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: generator_A_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = generator_A_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def generator__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_A_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: generator_A_gen
 L0:
     return __mypyc_self__
-def generator__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_A_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_A_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -993,20 +993,20 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = generator_A_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def A.generator(self):
     self :: A
-    r0 :: generator__env
+    r0 :: generator_A_env
     r1 :: bool
-    r2 :: generator__gen
+    r2 :: generator_A_gen
     r3 :: bool
     r4 :: short_int
     r5 :: bool
 L0:
-    r0 = generator__env()
+    r0 = generator_A_env()
     r0.self = self; r1 = is_error
-    r2 = generator__gen()
+    r2 = generator_A_gen()
     r2.__mypyc_env__ = r0; r3 = is_error
     r4 = 0
     r0.__mypyc_next_label__ = r4; r5 = is_error
@@ -1022,10 +1022,10 @@ def generator(a: int) -> Generator:
         return
 
 [out]
-def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_gen
     type, value, traceback :: object
-    r0 :: generator__env
+    r0 :: generator_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -1113,19 +1113,19 @@ L14:
 L15:
     raise StopIteration
     unreachable
-def generator__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: generator_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = generator_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def generator__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: generator_gen
 L0:
     return __mypyc_self__
-def generator__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -1137,20 +1137,20 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = generator_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def generator(a):
     a :: int
-    r0 :: generator__env
+    r0 :: generator_env
     r1 :: bool
-    r2 :: generator__gen
+    r2 :: generator_gen
     r3 :: bool
     r4 :: short_int
     r5 :: bool
 L0:
-    r0 = generator__env()
+    r0 = generator_env()
     r0.a = a; r1 = is_error
-    r2 = generator__gen()
+    r2 = generator_gen()
     r2.__mypyc_env__ = r0; r3 = is_error
     r4 = 0
     r0.__mypyc_next_label__ = r4; r5 = is_error
@@ -1207,7 +1207,7 @@ L2:
 def normal_generator_obj.__call__(__mypyc_self__, x):
     __mypyc_self__ :: normal_generator_obj
     x :: int
-    r0 :: generator__env
+    r0 :: generator_env
     r1, normal :: object
     r2, r3 :: int
 L0:
@@ -1217,10 +1217,10 @@ L0:
     r2 = r0.a
     r3 = r2 + x :: int
     return r3
-def generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_gen
     type, value, traceback :: object
-    r0 :: generator__env
+    r0 :: generator_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -1297,19 +1297,19 @@ L10:
 L11:
     raise StopIteration
     unreachable
-def generator__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: generator_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = generator_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def generator__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: generator__gen
+def generator_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: generator_gen
 L0:
     return __mypyc_self__
-def generator__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: generator__gen
+def generator_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: generator_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -1321,20 +1321,20 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = generator__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = generator_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def generator(a):
     a :: int
-    r0 :: generator__env
+    r0 :: generator_env
     r1 :: bool
-    r2 :: generator__gen
+    r2 :: generator_gen
     r3 :: bool
     r4 :: short_int
     r5 :: bool
 L0:
-    r0 = generator__env()
+    r0 = generator_env()
     r0.a = a; r1 = is_error
-    r2 = generator__gen()
+    r2 = generator_gen()
     r2.__mypyc_env__ = r0; r3 = is_error
     r4 = 0
     r0.__mypyc_next_label__ = r4; r5 = is_error
@@ -1357,7 +1357,7 @@ def generator_normal_gen.__mypyc_generator_helper__(__mypyc_self__, type, value,
     type, value, traceback :: object
     r0 :: generator_normal_env
     r1 :: int
-    r2, r3 :: normal__env
+    r2, r3 :: normal_env
     r4, generator, r5 :: object
     r6, r7 :: bool
     r8 :: int
@@ -1485,7 +1485,7 @@ L4:
 def generator_normal_obj.__call__(__mypyc_self__, x):
     __mypyc_self__ :: generator_normal_obj
     x :: int
-    r0 :: normal__env
+    r0 :: normal_env
     r1, generator :: object
     r2 :: generator_normal_env
     r3, r4 :: bool
@@ -1507,13 +1507,13 @@ L0:
     return r5
 def normal(a):
     a :: int
-    r0 :: normal__env
+    r0 :: normal_env
     r1 :: bool
     r2 :: generator_normal_obj
     r3, r4 :: bool
     r5 :: object
 L0:
-    r0 = normal__env()
+    r0 = normal_env()
     r0.a = a; r1 = is_error
     r2 = generator_normal_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
@@ -1549,7 +1549,7 @@ L2:
 def inner_triple_generator_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_triple_generator_obj
     r0 :: generator_triple_env
-    r1 :: triple__env
+    r1 :: triple_env
     r2, inner :: object
     r3 :: int
     r4 :: short_int
@@ -1572,7 +1572,7 @@ def generator_triple_gen.__mypyc_generator_helper__(__mypyc_self__, type, value,
     type, value, traceback :: object
     r0 :: generator_triple_env
     r1 :: int
-    r2, r3 :: triple__env
+    r2, r3 :: triple_env
     r4, generator, r5 :: object
     r6, r7 :: bool
     r8 :: short_int
@@ -1692,7 +1692,7 @@ L4:
     return r1
 def generator_triple_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: generator_triple_obj
-    r0 :: triple__env
+    r0 :: triple_env
     r1, generator :: object
     r2 :: generator_triple_env
     r3 :: bool
@@ -1712,12 +1712,12 @@ L0:
     r2.__mypyc_next_label__ = r6; r7 = is_error
     return r4
 def triple():
-    r0 :: triple__env
+    r0 :: triple_env
     r1 :: generator_triple_obj
     r2, r3 :: bool
     r4 :: object
 L0:
-    r0 = triple__env()
+    r0 = triple_env()
     r1 = generator_triple_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.generator = r1; r3 = is_error
@@ -1741,7 +1741,7 @@ def recursive_outer_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, 
     type, value, traceback :: object
     r0 :: recursive_outer_env
     r1 :: int
-    r2, r3 :: outer__env
+    r2, r3 :: outer_env
     r4, recursive, r5 :: object
     r6, r7 :: bool
     r8 :: int
@@ -1940,7 +1940,7 @@ L4:
 def recursive_outer_obj.__call__(__mypyc_self__, n):
     __mypyc_self__ :: recursive_outer_obj
     n :: int
-    r0 :: outer__env
+    r0 :: outer_env
     r1, recursive :: object
     r2 :: recursive_outer_env
     r3, r4 :: bool
@@ -1961,13 +1961,13 @@ L0:
     r2.__mypyc_next_label__ = r7; r8 = is_error
     return r5
 def outer():
-    r0 :: outer__env
+    r0 :: outer_env
     r1 :: recursive_outer_obj
     r2, r3 :: bool
     r4 :: short_int
     r5, r6, r7 :: object
 L0:
-    r0 = outer__env()
+    r0 = outer_env()
     r1 = recursive_outer_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.recursive = r1; r3 = is_error
@@ -1991,10 +1991,10 @@ def yield_try_finally() -> Generator[int, None, str]:
         print('goodbye!')
 
 [out]
-def yield_try_finally__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_try_finally__gen
+def yield_try_finally_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_try_finally_gen
     type, value, traceback :: object
-    r0 :: yield_try_finally__env
+    r0 :: yield_try_finally_env
     r1 :: int
     r2 :: object
     r3, r4 :: bool
@@ -2175,19 +2175,19 @@ L37:
 L38:
     raise StopIteration
     unreachable
-def yield_try_finally__gen.__next__(__mypyc_self__):
-    __mypyc_self__ :: yield_try_finally__gen
+def yield_try_finally_gen.__next__(__mypyc_self__):
+    __mypyc_self__ :: yield_try_finally_gen
     r0, r1 :: object
 L0:
     r0 = builtins.None :: object
-    r1 = yield_try_finally__gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
+    r1 = yield_try_finally_gen.__mypyc_generator_helper__(__mypyc_self__, r0, r0, r0)
     return r1
-def yield_try_finally__gen.__iter__(__mypyc_self__):
-    __mypyc_self__ :: yield_try_finally__gen
+def yield_try_finally_gen.__iter__(__mypyc_self__):
+    __mypyc_self__ :: yield_try_finally_gen
 L0:
     return __mypyc_self__
-def yield_try_finally__gen.throw(__mypyc_self__, type, value, traceback):
-    __mypyc_self__ :: yield_try_finally__gen
+def yield_try_finally_gen.throw(__mypyc_self__, type, value, traceback):
+    __mypyc_self__ :: yield_try_finally_gen
     type, value, traceback, r0, r1 :: object
 L0:
     r0 = builtins.None :: object
@@ -2199,18 +2199,19 @@ L2:
 L3:
     traceback = r0
 L4:
-    r1 = yield_try_finally__gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
+    r1 = yield_try_finally_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, traceback)
     return r1
 def yield_try_finally():
-    r0 :: yield_try_finally__env
-    r1 :: yield_try_finally__gen
+    r0 :: yield_try_finally_env
+    r1 :: yield_try_finally_gen
     r2 :: bool
     r3 :: short_int
     r4 :: bool
 L0:
-    r0 = yield_try_finally__env()
-    r1 = yield_try_finally__gen()
+    r0 = yield_try_finally_env()
+    r1 = yield_try_finally_gen()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = 0
     r0.__mypyc_next_label__ = r3; r4 = is_error
     return r1
+

--- a/test-data/genops-nested.test
+++ b/test-data/genops-nested.test
@@ -49,7 +49,7 @@ L2:
     return r2
 def inner_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_a_obj
-    r0 :: a__env
+    r0 :: a_env
     r1, inner :: object
     r2 :: None
     r3 :: object
@@ -61,12 +61,12 @@ L0:
     r3 = box(None, r2)
     return r3
 def a():
-    r0 :: a__env
+    r0 :: a_env
     r1 :: inner_a_obj
     r2, r3 :: bool
     r4 :: object
 L0:
-    r0 = a__env()
+    r0 = a_env()
     r1 = inner_a_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.inner = r1; r3 = is_error
@@ -88,7 +88,7 @@ L2:
 def second_b_first_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: second_b_first_obj
     r0 :: first_b_env
-    r1 :: b__env
+    r1 :: b_env
     r2, second :: object
     r3 :: str
 L0:
@@ -113,7 +113,7 @@ L2:
     return r2
 def first_b_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: first_b_obj
-    r0 :: b__env
+    r0 :: b_env
     r1, first :: object
     r2 :: first_b_env
     r3 :: bool
@@ -132,12 +132,12 @@ L0:
     r7 = r2.second
     return r7
 def b():
-    r0 :: b__env
+    r0 :: b_env
     r1 :: first_b_obj
     r2, r3 :: bool
     r4 :: object
 L0:
-    r0 = b__env()
+    r0 = b_env()
     r1 = first_b_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.first = r1; r3 = is_error
@@ -159,7 +159,7 @@ L2:
 def inner_c_obj.__call__(__mypyc_self__, s):
     __mypyc_self__ :: inner_c_obj
     s :: str
-    r0 :: c__env
+    r0 :: c_env
     r1, inner :: object
     r2, r3 :: str
 L0:
@@ -171,12 +171,12 @@ L0:
     return r3
 def c(num):
     num :: float
-    r0 :: c__env
+    r0 :: c_env
     r1 :: inner_c_obj
     r2, r3 :: bool
     r4 :: object
 L0:
-    r0 = c__env()
+    r0 = c_env()
     r1 = inner_c_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.inner = r1; r3 = is_error
@@ -198,7 +198,7 @@ L2:
 def inner_d_obj.__call__(__mypyc_self__, s):
     __mypyc_self__ :: inner_d_obj
     s :: str
-    r0 :: d__env
+    r0 :: d_env
     r1, inner :: object
     r2, r3 :: str
 L0:
@@ -210,7 +210,7 @@ L0:
     return r3
 def d(num):
     num :: float
-    r0 :: d__env
+    r0 :: d_env
     r1 :: inner_d_obj
     r2, r3 :: bool
     r4 :: str
@@ -219,7 +219,7 @@ def d(num):
     r9, r10 :: object
     r11, b :: str
 L0:
-    r0 = d__env()
+    r0 = d_env()
     r1 = inner_d_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r0.inner = r1; r3 = is_error
@@ -292,7 +292,7 @@ L2:
     return r2
 def inner_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_a_obj
-    r0 :: a__env
+    r0 :: a_env
     r1, inner :: object
     r2 :: int
 L0:
@@ -303,14 +303,14 @@ L0:
     return r2
 def a(num):
     num :: int
-    r0 :: a__env
+    r0 :: a_env
     r1 :: bool
     r2 :: inner_a_obj
     r3, r4 :: bool
     r5, r6 :: object
     r7 :: int
 L0:
-    r0 = a__env()
+    r0 = a_env()
     r0.num = num; r1 = is_error
     r2 = inner_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
@@ -334,7 +334,7 @@ L2:
     return r2
 def inner_b_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_b_obj
-    r0 :: b__env
+    r0 :: b_env
     r1, inner :: object
     r2 :: short_int
     r3 :: bool
@@ -351,7 +351,7 @@ L0:
     r5 = r0.num
     return r5
 def b():
-    r0 :: b__env
+    r0 :: b_env
     r1 :: short_int
     r2 :: bool
     r3 :: inner_b_obj
@@ -359,7 +359,7 @@ def b():
     r6, r7 :: object
     r8, r9, r10 :: int
 L0:
-    r0 = b__env()
+    r0 = b_env()
     r1 = 3
     r0.num = r1; r2 = is_error
     r3 = inner_b_obj()
@@ -386,7 +386,7 @@ L2:
     return r2
 def inner_c_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_c_obj
-    r0 :: c__env
+    r0 :: c_env
     r1, inner :: object
     r2 :: str
 L0:
@@ -410,7 +410,7 @@ L2:
     return r2
 def inner_c_obj_0.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_c_obj_0
-    r0 :: c__env
+    r0 :: c_env
     r1, inner :: object
     r2 :: str
 L0:
@@ -421,7 +421,7 @@ L0:
     return r2
 def c(flag):
     flag :: bool
-    r0 :: c__env
+    r0 :: c_env
     r1 :: inner_c_obj
     r2, r3 :: bool
     r4 :: inner_c_obj_0
@@ -429,7 +429,7 @@ def c(flag):
     r7, r8 :: object
     r9 :: str
 L0:
-    r0 = c__env()
+    r0 = c_env()
     if flag goto L1 else goto L2 :: bool
 L1:
     r1 = inner_c_obj()
@@ -473,7 +473,7 @@ L2:
 def c_a_b_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: c_a_b_obj
     r0 :: b_a_env
-    r1 :: a__env
+    r1 :: a_env
     r2, c :: object
     r3 :: int
 L0:
@@ -498,7 +498,7 @@ L2:
     return r2
 def b_a_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: b_a_obj
-    r0 :: a__env
+    r0 :: a_env
     r1, b :: object
     r2 :: b_a_env
     r3 :: bool
@@ -528,7 +528,7 @@ L0:
     r13 = unbox(int, r12)
     return r13
 def a():
-    r0 :: a__env
+    r0 :: a_env
     r1 :: short_int
     r2 :: bool
     r3 :: b_a_obj
@@ -536,7 +536,7 @@ def a():
     r6, r7 :: object
     r8 :: int
 L0:
-    r0 = a__env()
+    r0 = a_env()
     r1 = 1
     r0.x = r1; r2 = is_error
     r3 = b_a_obj()
@@ -572,7 +572,7 @@ L2:
     return r2
 def inner_f_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_f_obj
-    r0 :: f__env
+    r0 :: f_env
     r1, inner :: object
     r2 :: str
 L0:
@@ -596,7 +596,7 @@ L2:
     return r2
 def inner_f_obj_0.__call__(__mypyc_self__):
     __mypyc_self__ :: inner_f_obj_0
-    r0 :: f__env
+    r0 :: f_env
     r1, inner :: object
     r2 :: str
 L0:
@@ -607,7 +607,7 @@ L0:
     return r2
 def f(flag):
     flag :: bool
-    r0 :: f__env
+    r0 :: f_env
     r1 :: inner_f_obj
     r2, r3 :: bool
     r4 :: inner_f_obj_0
@@ -615,7 +615,7 @@ def f(flag):
     r7, r8 :: object
     r9 :: str
 L0:
-    r0 = f__env()
+    r0 = f_env()
     if flag goto L1 else goto L2 :: bool
 L1:
     r1 = inner_f_obj()
@@ -665,7 +665,7 @@ L2:
     return r2
 def foo_f_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: foo_f_obj
-    r0 :: f__env
+    r0 :: f_env
     r1, foo :: object
     r2 :: int
     r3 :: short_int
@@ -693,7 +693,7 @@ L2:
     return r2
 def bar_f_obj.__call__(__mypyc_self__):
     __mypyc_self__ :: bar_f_obj
-    r0 :: f__env
+    r0 :: f_env
     r1, bar, r2, r3 :: object
     r4 :: int
 L0:
@@ -720,7 +720,7 @@ L2:
 def baz_f_obj.__call__(__mypyc_self__, n):
     __mypyc_self__ :: baz_f_obj
     n :: int
-    r0 :: f__env
+    r0 :: f_env
     r1, baz :: object
     r2 :: short_int
     r3 :: bool
@@ -748,7 +748,7 @@ L2:
     return r10
 def f(a):
     a :: int
-    r0 :: f__env
+    r0 :: f_env
     r1 :: bool
     r2 :: foo_f_obj
     r3, r4 :: bool
@@ -761,7 +761,7 @@ def f(a):
     r15, r16, r17 :: object
     r18, r19 :: int
 L0:
-    r0 = f__env()
+    r0 = f_env()
     r0.a = a; r1 = is_error
     r2 = foo_f_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
@@ -805,7 +805,7 @@ L2:
 def __mypyc_lambda__0_f_obj.__call__(__mypyc_self__, a, b):
     __mypyc_self__ :: __mypyc_lambda__0_f_obj
     a, b :: object
-    r0 :: f__env
+    r0 :: f_env
     r1 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
@@ -813,13 +813,13 @@ L0:
     return r1
 def f(x, y):
     x, y :: int
-    r0 :: f__env
+    r0 :: f_env
     r1 :: __mypyc_lambda__0_f_obj
     r2 :: bool
     s, r3, r4, r5 :: object
     r6 :: None
 L0:
-    r0 = f__env()
+    r0 = f_env()
     r1 = __mypyc_lambda__0_f_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     s = r1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3561,3 +3561,25 @@ try:
     assert native.version() == sys.version_info[1]
 except RuntimeError:
     assert version == (3, 5), "only 3.5 should fail!"
+
+[case testGeneratorNameClash]
+class A:
+    def foo(self) -> object:
+        yield
+class B:
+    def foo(self) -> object:
+        yield
+[file driver.py]
+# really I only care it builds
+
+[case testNestedFuncNameClash]
+class A:
+    def foo(self) -> None:
+        def bar(self) -> None:
+            pass
+class B:
+    def foo(self) -> None:
+        def bar(self) -> None:
+            pass
+[file driver.py]
+# really I only care it builds


### PR DESCRIPTION
This fixes C compilation failures in some cases where functions
share a name.

Closes #493.