### PR TITLE
Support windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Linux Requirements
 Windows Requirements
 --------------------
 
-Windows is currently unsupported.
+* Windows has been tested with Windows 10 and MSVC 2017.
+
+* Python 3.5+ (64-bit)
 
 Quick Start for Contributors
 ----------------------------

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -64,6 +64,9 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     PyObject *bases = NULL;
     PyObject *slots;
 
+    // If the type of the class (the metaclass) is NULL, we default it
+    // to being type.  (This allows us to avoid needing to initialize
+    // it explicitly on windows.)
     if (!Py_TYPE(template_)) {
         Py_TYPE(template_) = &PyType_Type;
     }

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -64,6 +64,9 @@ static inline PyObject *CPyType_FromTemplate(PyTypeObject *template_,
     PyObject *bases = NULL;
     PyObject *slots;
 
+    if (!Py_TYPE(template_)) {
+        Py_TYPE(template_) = &PyType_Type;
+    }
     PyTypeObject *metaclass = Py_TYPE(template_);
 
     if (orig_bases) {
@@ -897,7 +900,7 @@ static void CPy_AddTraceback(const char *filename, const char *funcname, int lin
 // exception APIs that might want to return NULL pointers instead
 // return properly refcounted pointers to this dummy object.
 struct ExcDummyStruct { PyObject_HEAD };
-static struct ExcDummyStruct _CPy_ExcDummyStruct = { PyObject_HEAD_INIT(&PyBaseObject_Type) };
+static struct ExcDummyStruct _CPy_ExcDummyStruct = { PyObject_HEAD_INIT(NULL) };
 static PyObject *_CPy_ExcDummy = (PyObject *)&_CPy_ExcDummyStruct;
 
 static inline void _CPy_ToDummy(PyObject **p) {
@@ -1012,6 +1015,14 @@ static void CPy_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_t
     _CPy_ToNone(p_type);
     _CPy_ToNone(p_value);
     _CPy_ToNone(p_traceback);
+}
+
+// Because its dynamic linker is more restricted than linux/OS X,
+// Windows doesn't allow initializing globals with values from
+// other dynamic libraries. This means we need to initialize
+// things at load time.
+static void CPy_Init(void) {
+    _CPy_ExcDummyStruct.ob_base.ob_type = &PyBaseObject_Type;
 }
 
 #ifdef __cplusplus

--- a/lib-rt/mypyc_util.h
+++ b/lib-rt/mypyc_util.h
@@ -5,9 +5,23 @@
 #include <frameobject.h>
 #include <assert.h>
 
+#if defined(__clang__) || defined(__GNUC__)
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
 #define CPy_Unreachable() __builtin_unreachable()
+#define CPy_dllexport __attribute__ ((dllexport))
+#else
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#define CPy_Unreachable() abort()
+
+#if defined(_MSC_VER)
+#define CPy_dllexport __declspec(dllexport)
+#else
+#define CPy_dllexport
+#endif
+
+#endif
 
 #define CPY_TAGGED_MAX ((1LL << 62) - 1)
 #define CPY_TAGGED_MIN (-(1LL << 62))

--- a/lib-rt/mypyc_util.h
+++ b/lib-rt/mypyc_util.h
@@ -9,18 +9,16 @@
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
 #define CPy_Unreachable() __builtin_unreachable()
-#define CPy_dllexport __attribute__ ((dllexport))
 #else
 #define likely(x)       (x)
 #define unlikely(x)     (x)
 #define CPy_Unreachable() abort()
+#endif
 
 #if defined(_MSC_VER)
 #define CPy_dllexport __declspec(dllexport)
 #else
 #define CPy_dllexport
-#endif
-
 #endif
 
 #define CPY_TAGGED_MAX ((1LL << 62) - 1)

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -378,15 +378,15 @@ def mypycify(paths: List[str],
             '-Wno-unreachable-code', '-Wno-unused-variable', '-Wno-trigraphs',
             '-Wno-unused-command-line-argument'
         ]
+        if 'gcc' in compiler.compiler[0]:
+            # This flag is needed for gcc but does not exist on clang.
+            cflags += ['-Wno-unused-but-set-variable']
     elif compiler.compiler_type == 'msvc':
         if opt_level == '3':
             opt_level = '2'
         cflags += [
             '/O{}'.format(opt_level)
         ]
-    if 'gcc' in compiler.compiler[0]:
-        # This flag is needed for gcc but does not exist on clang.
-        cflags += ['-Wno-unused-but-set-variable']
 
     if use_shared_lib:
         assert lib_name

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -126,7 +126,7 @@ def get_mypy_config(paths: List[str],
     return sources, options
 
 
-shim_template = """\
+shim_template_unix = """\
 #include <Python.h>
 
 PyObject *CPyInit_{full_modname}(void);
@@ -138,6 +138,56 @@ PyInit_{modname}(void)
 }}
 """
 
+# As far as I could tell, Windows lacks the rpath style features
+# we would need in order to do everything at load time, which means
+# that instead we get to do it dynamically.
+shim_template_windows = r"""\
+#include <Python.h>
+#include <windows.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+
+typedef PyObject *(__cdecl *INITPROC)();
+
+PyMODINIT_FUNC
+PyInit_{modname}(void)
+{{
+    char path[MAX_PATH];
+    char drive[MAX_PATH];
+    char directory[MAX_PATH];
+    HINSTANCE hinstLib;
+    INITPROC proc;
+
+    DWORD res = GetModuleFileName((HINSTANCE)&__ImageBase, path, sizeof(path));
+    if (res == 0 || res == sizeof(path)) {{
+        PyErr_SetString(PyExc_RuntimeError, "GetModuleFileName failed");
+        return NULL;
+    }}
+
+    _splitpath(path, drive, directory, NULL, NULL);
+    snprintf(path, sizeof(path), "%s%s%s", drive, directory, MYPYC_LIBRARY);
+
+    hinstLib = LoadLibrary(path);
+    if (!hinstLib) {{
+        PyErr_SetString(PyExc_RuntimeError, "LoadLibrary failed");
+        return NULL;
+    }}
+    proc = (INITPROC)GetProcAddress(hinstLib, "CPyInit_{full_modname}");
+    if (!proc) {{
+        PyErr_SetString(PyExc_RuntimeError, "GetProcAddress failed");
+        return NULL;
+    }}
+
+    return proc();
+}}
+
+// distutils sometimes spuriously tells cl to export CPyInit___init__,
+// so provide that so it chills out
+PyMODINIT_FUNC PyInit___init__(void) {{ return PyInit_{modname}(); }}
+"""
+
 
 def generate_c_extension_shim(full_module_name: str, module_name: str, dirname: str) -> str:
     """Create a C extension shim with a passthrough PyInit function."""
@@ -145,6 +195,7 @@ def generate_c_extension_shim(full_module_name: str, module_name: str, dirname: 
     cpath = os.path.join(dirname, cname)
 
     with open(cpath, 'w') as f:
+        shim_template = shim_template_windows if sys.platform == 'win32' else shim_template_unix
         f.write(shim_template.format(modname=module_name,
                                      full_modname=exported_name(full_module_name)))
 
@@ -164,7 +215,7 @@ def include_dir() -> str:
 
 
 def generate_c(sources: List[BuildSource], options: Options,
-               use_shared_lib: bool) -> Tuple[str, str]:
+               shared_lib_name: Optional[str]) -> Tuple[str, str]:
     """Drive the actual core compilation step.
 
     Returns the C source code and (for debugging) the pretty printed IR.
@@ -184,7 +235,7 @@ def generate_c(sources: List[BuildSource], options: Options,
     print("Parsed and typechecked in {:.3f}s".format(t1 - t0))
 
     ops = []  # type: List[str]
-    ctext = emitmodule.compile_modules_to_c(result, module_names, use_shared_lib, ops=ops)
+    ctext = emitmodule.compile_modules_to_c(result, module_names, shared_lib_name, ops=ops)
 
     t2 = time.time()
     print("Compiled to C in {:.3f}s".format(t2 - t1))
@@ -270,6 +321,14 @@ def mypycify(paths: List[str],
       * opt_level: The optimization level, as a string. Defaults to '3' (meaning '-O3').
     """
 
+    # XXX: what is the right way to figure this out??
+    if sys.platform == 'win32':
+        compiler = 'msvc'
+    elif sys.platform == 'darwin':
+        compiler = 'clang'
+    else:
+        compiler = 'clang' if 'clang' in os.getenv('CC', '') else 'gcc'
+
     setup_mypycify_vars()
 
     expanded_paths = []
@@ -289,29 +348,38 @@ def mypycify(paths: List[str],
     use_shared_lib = len(sources) > 1 or any('.' in x.module for x in sources)
     cfile = os.path.join(build_dir, '__native.c')
 
+    lib_name = shared_lib_name([source.module for source in sources]) if use_shared_lib else None
+
     # We let the test harness make us skip doing the full compilation
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        ctext, ops_text = generate_c(sources, options, use_shared_lib)
+        ctext, ops_text = generate_c(sources, options, lib_name)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)
-        with open(cfile, 'w') as f:
+        with open(cfile, 'w', encoding='utf-8') as f:
             f.write(ctext)
 
-    cflags = [
-        '-O{}'.format(opt_level),
-        '-Werror', '-Wno-unused-function', '-Wno-unused-label',
-        '-Wno-unreachable-code', '-Wno-unused-variable', '-Wno-trigraphs',
-        '-Wno-unused-command-line-argument'
-    ]
-    if sys.platform == 'linux' and 'clang' not in os.getenv('CC', ''):
+    cflags = []  # type: List[str]
+    if compiler in ('clang', 'gcc'):
+        cflags += [
+            '-O{}'.format(opt_level), '-Werror', '-Wno-unused-function', '-Wno-unused-label',
+            '-Wno-unreachable-code', '-Wno-unused-variable', '-Wno-trigraphs',
+            '-Wno-unused-command-line-argument'
+        ]
+    elif compiler == 'msvc':
+        if opt_level == '3':
+            opt_level = '2'
+        cflags += [
+            '/O{}'.format(opt_level)
+        ]
+    if compiler == 'gcc':
         # This flag is needed for gcc but does not exist on clang.
         cflags += ['-Wno-unused-but-set-variable']
 
     if use_shared_lib:
-        lib_name = shared_lib_name([source.module for source in sources])
+        assert lib_name
         extensions = build_using_shared_lib(sources, lib_name, cfile, build_dir, cflags)
     else:
         extensions = build_single_module(sources, cfile, cflags)
@@ -358,8 +426,18 @@ class MypycifyBuildExt(build_ext):
             shared_dir, shared_file = os.path.split(
                 self.get_ext_fullpath(ext.mypyc_shared_target.name))
             shared_name = os.path.splitext(shared_file)[0][3:]
-            ext.libraries.append(shared_name)
-            ext.library_dirs.append(shared_dir)
+            if sys.platform == 'win32':
+                # On windows, instead of linking against the shared library,
+                # we dynamically load it at runtime. We generate our C shims
+                # before we have found out what the library filename is, so
+                # pass it in as a preprocessor define.
+                path = os.path.join(relative_lib_path, shared_file)
+                ext.extra_compile_args.append(
+                    '/DMYPYC_LIBRARY=\\"{}\\"'.format(path.replace('\\', '\\\\')))
+            else:
+                # On other platforms we link against the library normally
+                ext.libraries.append(shared_name)
+                ext.library_dirs.append(shared_dir)
             if sys.platform == 'linux':
                 ext.runtime_library_dirs.append('$ORIGIN/{}'.format(
                     relative_lib_path))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -186,7 +186,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     fields['tp_flags'] = ' | '.join(flags)
 
     emitter.emit_line("static PyTypeObject {}_template_ = {{".format(emitter.type_struct_name(cl)))
-    emitter.emit_line("PyVarObject_HEAD_INIT(&PyType_Type, 0)")
+    emitter.emit_line("PyVarObject_HEAD_INIT(NULL, 0)")
     for field, value in fields.items():
         emitter.emit_line(".{} = {},".format(field, value))
     emitter.emit_line("};")
@@ -305,6 +305,9 @@ def generate_vtable(entries: VTableEntries,
             cl, attr, is_setter = entry
             namer = native_setter_name if is_setter else native_getter_name
             emitter.emit_line('(CPyVTableItem){},'.format(namer(cl, attr, emitter.names)))
+    # msvc doesn't allow empty arrays; maybe allowing them at all is an extension?
+    if not entries:
+        emitter.emit_line('NULL')
     emitter.emit_line('};')
 
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -42,7 +42,7 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
 
 
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
-                         use_shared_lib: bool,
+                         shared_lib_name: Optional[str],
                          ops: Optional[List[str]] = None) -> str:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
 
@@ -70,7 +70,7 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
     # Generate C code.
     source_paths = {module_name: result.files[module_name].path
                     for module_name in module_names}
-    generator = ModuleGenerator(literals, modules, source_paths, use_shared_lib)
+    generator = ModuleGenerator(literals, modules, source_paths, shared_lib_name)
     return generator.generate_c_for_modules()
 
 
@@ -100,13 +100,17 @@ class ModuleGenerator:
                  literals: LiteralsMap,
                  modules: List[Tuple[str, ModuleIR]],
                  source_paths: Dict[str, str],
-                 use_shared_lib: bool) -> None:
+                 shared_lib_name: Optional[str]) -> None:
         self.literals = literals
         self.modules = modules
         self.source_paths = source_paths
         self.context = EmitterContext([name for name, _ in modules])
         self.names = self.context.names
-        self.use_shared_lib = use_shared_lib
+        # Initializations of globals to simple values that we can't
+        # do statically because the windows loader is bad.
+        self.simple_inits = {}  # type: Dict[str, str]
+        self.shared_lib_name = shared_lib_name
+        self.use_shared_lib = shared_lib_name is not None
 
     def generate_c_for_modules(self) -> str:
         emitter = Emitter(self.context)
@@ -133,7 +137,7 @@ class ModuleGenerator:
             for fn in module.functions:
                 generate_function_declaration(fn, emitter)
 
-        self.generate_literals(emitter)
+        self.generate_globals_init(emitter)
 
         classes = []
         for module_name, module in self.modules:
@@ -159,6 +163,18 @@ class ModuleGenerator:
                     emitter.emit_line()
                     generate_wrapper_function(fn, emitter)
 
+        # Generate a dummy initialization function for the shared lib,
+        # since the windows linker gets mad if it isn't present.
+        if self.shared_lib_name:
+            emitter.emit_line()
+            emitter.emit_lines(
+                'PyMODINIT_FUNC PyInit_lib{}(void)'.format(self.shared_lib_name),
+                '{',
+                'PyErr_SetString(PyExc_RuntimeError, "mypyc shared lib is not to be imported");',
+                'return NULL;',
+                '}',
+            )
+
         declarations = Emitter(self.context)
         declarations.emit_line('#include <Python.h>')
         declarations.emit_line('#include <CPy.h>')
@@ -172,14 +188,18 @@ class ModuleGenerator:
 
         return ''.join(declarations.fragments + emitter.fragments)
 
-    def generate_literals(self, emitter: Emitter) -> None:
+    def generate_globals_init(self, emitter: Emitter) -> None:
         emitter.emit_lines(
-            'static int CPyLiteralsInit(void)',
+            'static int CPyGlobalsInit(void)',
             '{',
             'static int is_initialized = 0;',
             'if (is_initialized) return 0;',
             ''
         )
+
+        emitter.emit_line('CPy_Init();')
+        for symbol, fixup in self.simple_inits.items():
+            emitter.emit_line('{} = {};'.format(symbol, fixup))
 
         for (_, literal), identifier in self.literals.items():
             symbol = emitter.static_name(identifier, None)
@@ -258,7 +278,8 @@ class ModuleGenerator:
             declaration = 'PyMODINIT_FUNC PyInit_{}(void)'.format(module_name)
         else:
             declaration = 'PyObject *CPyInit_{}(void)'.format(exported_name(module_name))
-        emitter.emit_lines(declaration,
+        emitter.emit_lines('CPy_dllexport',
+                           declaration,
                            '{')
         # Store the module reference in a static and return it when necessary.
         # This is separate from the *global* reference to the module that will
@@ -294,7 +315,7 @@ class ModuleGenerator:
                 emitter.emit_lines('if (unlikely(!{}))'.format(type_struct),
                                    '    return NULL;')
 
-        emitter.emit_lines('if (CPyLiteralsInit() < 0)',
+        emitter.emit_lines('if (CPyGlobalsInit() < 0)',
                            '    return NULL;')
 
         self.generate_top_level_call(module, emitter)
@@ -371,7 +392,8 @@ class ModuleGenerator:
         internal_static_name = self.module_internal_static_name(module_name, emitter)
         self.declare_global('CPyModule *', internal_static_name, initializer='NULL')
         static_name = emitter.static_name('module', module_name)
-        self.declare_global('CPyModule *', static_name, initializer='Py_None')
+        self.declare_global('CPyModule *', static_name)
+        self.simple_inits[static_name] = 'Py_None'
 
     def declare_imports(self, imps: Iterable[str], emitter: Emitter) -> None:
         for imp in imps:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -108,7 +108,7 @@ class ModuleGenerator:
         self.names = self.context.names
         # Initializations of globals to simple values that we can't
         # do statically because the windows loader is bad.
-        self.simple_inits = {}  # type: Dict[str, str]
+        self.simple_inits = []  # type: List[Tuple[str, str]]
         self.shared_lib_name = shared_lib_name
         self.use_shared_lib = shared_lib_name is not None
 
@@ -198,7 +198,7 @@ class ModuleGenerator:
         )
 
         emitter.emit_line('CPy_Init();')
-        for symbol, fixup in self.simple_inits.items():
+        for symbol, fixup in self.simple_inits:
             emitter.emit_line('{} = {};'.format(symbol, fixup))
 
         for (_, literal), identifier in self.literals.items():
@@ -393,7 +393,7 @@ class ModuleGenerator:
         self.declare_global('CPyModule *', internal_static_name, initializer='NULL')
         static_name = emitter.static_name('module', module_name)
         self.declare_global('CPyModule *', static_name)
-        self.simple_inits[static_name] = 'Py_None'
+        self.simple_inits.append((static_name, 'Py_None'))
 
     def declare_imports(self, imps: Iterable[str], emitter: Emitter) -> None:
         for imp in imps:

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -46,7 +46,9 @@ class TestCommandLine(MypycDataSuite):
 
         try:
             # Compile program
-            subprocess.check_call(['%s/scripts/mypyc' % base_path] + args, cwd='tmp')
+            subprocess.check_call([sys.executable,
+                                   os.path.join(base_path, 'scripts', 'mypyc')] + args,
+                                  cwd='tmp')
 
             # Run main program
             out = subprocess.check_output(
@@ -54,6 +56,7 @@ class TestCommandLine(MypycDataSuite):
                 cwd='tmp')
         finally:
             so_paths = glob.glob('tmp/**/*.so', recursive=True)
+            so_paths += glob.glob('tmp/**/*.pyd', recursive=True)
             for path in so_paths:
                 os.remove(path)
 

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -55,8 +55,8 @@ class TestCommandLine(MypycDataSuite):
                 [python3_path, program],
                 cwd='tmp')
         finally:
-            so_paths = glob.glob('tmp/**/*.so', recursive=True)
-            so_paths += glob.glob('tmp/**/*.pyd', recursive=True)
+            suffix = 'pyd' if sys.platform == 'win32' else 'so'
+            so_paths = glob.glob('tmp/**/*.{}'.format(suffix), recursive=True)
             for path in so_paths:
                 os.remove(path)
 

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -46,7 +46,7 @@ class TestCompiler(MypycDataSuite):
                     options=options,
                     alt_lib_path=test_temp_dir)
                 ctext = emitmodule.compile_modules_to_c(
-                    result, module_names=['prog'], use_shared_lib=False)
+                    result, module_names=['prog'], shared_lib_name=None)
                 out = ctext.splitlines()
             except CompileError as e:
                 out = e.messages

--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -10,12 +10,13 @@ base_dir = os.path.join(os.path.dirname(__file__), '..', '..')
 
 
 class TestExternal(unittest.TestCase):
+    # TODO: Get this to work on Windows.
+    # (Or don't. It is probably not a good use of time.)
+    @unittest.skipIf(sys.platform.startswith("win"), "rt tests don't work on windows")
     def test_c_unit_test(self) -> None:
         """Run C unit tests in a subprocess."""
         # Build Google Test, the C++ framework we use for testing C code.
         # The source code for Google Test is copied to this repository.
-        #
-        # TODO: Get this to work on Windows.
         if sys.platform == 'darwin':
             env = {'CPPFLAGS': '-mmacosx-version-min=10.10'}
         else:
@@ -38,8 +39,9 @@ class TestExternal(unittest.TestCase):
         mypy_dir = os.path.join(base_dir, 'external', 'mypy')
         if not os.path.exists(os.path.join(mypy_dir, 'mypy', 'typeshed', 'stdlib')):
             raise AssertionError('Submodule mypy/mypy/typeshed not ready')
-        env = {'PYTHONPATH': mypy_dir,
-               'MYPYPATH': '%s:%s' % (mypy_dir, base_dir)}
+        env = os.environ.copy()
+        env['PYTHONPATH'] = mypy_dir
+        env['MYPYPATH'] = os.pathsep.join((mypy_dir, base_dir))
         status = subprocess.call(
             [sys.executable,
              '-m', 'mypy',

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -147,7 +147,8 @@ class TestRun(MypycDataSuite):
             run_setup(setup_file, ['build_ext', '--inplace'])
             # Oh argh run_setup doesn't propagate failure. For now we'll just assert
             # that the file is there.
-            if not glob.glob('native.*.so') and not glob.glob('native.*.pyd'):
+            suffix = 'pyd' if sys.platform == 'win32' else 'so'
+            if not glob.glob('native.*.{}'.format(suffix)):
                 show_c(ctext)
                 assert False, "Compilation failed"
 

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -92,9 +92,9 @@ class TestRun(MypycDataSuite):
             os.mkdir(workdir)
 
             source_path = 'native.py'
-            with open(source_path, 'w') as f:
+            with open(source_path, 'w', encoding='utf-8') as f:
                 f.write(text)
-            with open('interpreted.py', 'w') as f:
+            with open('interpreted.py', 'w', encoding='utf-8') as f:
                 f.write(text)
 
             source = build.BuildSource(source_path, 'native', text)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -6,7 +6,7 @@ import platform
 import subprocess
 import contextlib
 import sys
-from typing import List, Iterator
+from typing import List, Iterator, Optional
 
 from mypy import build
 from mypy.test.data import DataDrivenTestCase
@@ -17,6 +17,7 @@ from mypy.options import Options
 from mypyc import genops
 from mypyc import emitmodule
 from mypyc.test.config import prefix
+from mypyc.build import shared_lib_name
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output,
     heading, show_c
@@ -116,6 +117,11 @@ class TestRun(MypycDataSuite):
             for source in sources:
                 options.per_module_options.setdefault(source.module, {})['mypyc'] = True
 
+            if len(module_names) == 1:
+                lib_name = None  # type: Optional[str]
+            else:
+                lib_name = shared_lib_name([source.module for source in sources])
+
             try:
                 result = emitmodule.parse_and_typecheck(
                     sources=sources,
@@ -124,14 +130,14 @@ class TestRun(MypycDataSuite):
                 ctext = emitmodule.compile_modules_to_c(
                     result,
                     module_names=module_names,
-                    use_shared_lib=len(module_names) > 1)
+                    shared_lib_name=lib_name)
             except CompileError as e:
                 for line in e.messages:
                     print(line)
                 assert False, 'Compile error'
 
             cpath = os.path.abspath(os.path.join(workdir, '__native.c'))
-            with open(cpath, 'w') as f:
+            with open(cpath, 'w', encoding='utf-8') as f:
                 f.write(ctext)
 
             setup_file = os.path.abspath(os.path.join(workdir, 'setup.py'))
@@ -141,7 +147,7 @@ class TestRun(MypycDataSuite):
             run_setup(setup_file, ['build_ext', '--inplace'])
             # Oh argh run_setup doesn't propagate failure. For now we'll just assert
             # that the file is there.
-            if not glob.glob('native.*.so'):
+            if not glob.glob('native.*.so') and not glob.glob('native.*.pyd'):
                 show_c(ctext)
                 assert False, "Compilation failed"
 

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -9,19 +9,22 @@ def f(x: int) -> int:
 #include <CPy.h>
 
 static CPyModule *CPyStatic_module_internal = NULL;
-static CPyModule *CPyStatic_module = Py_None;
+static CPyModule *CPyStatic_module;
 static PyObject *CPyStatic_globals;
 static CPyModule *CPyStatic_builtins_module_internal = NULL;
-static CPyModule *CPyStatic_builtins_module = Py_None;
+static CPyModule *CPyStatic_builtins_module;
 static PyObject *CPyStatic_unicode_0;
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
 static char CPyDef___top_level__(void);
-static int CPyLiteralsInit(void)
+static int CPyGlobalsInit(void)
 {
     static int is_initialized = 0;
     if (is_initialized) return 0;
     
+    CPy_Init();
+    CPyStatic_module = Py_None;
+    CPyStatic_builtins_module = Py_None;
     CPyStatic_unicode_0 = PyUnicode_FromStringAndSize("builtins", 8);
     if (unlikely(CPyStatic_unicode_0 == NULL))
         return -1;
@@ -43,6 +46,7 @@ static struct PyModuleDef module = {
     module_methods
 };
 
+CPy_dllexport
 PyMODINIT_FUNC PyInit_prog(void)
 {
     if (CPyStatic_module_internal) {
@@ -56,7 +60,7 @@ PyMODINIT_FUNC PyInit_prog(void)
     CPyStatic_globals = PyModule_GetDict(CPyStatic_module_internal);
     if (unlikely(CPyStatic_globals == NULL))
         return NULL;
-    if (CPyLiteralsInit() < 0)
+    if (CPyGlobalsInit() < 0)
         return NULL;
     char result = CPyDef___top_level__();
     if (result == 2)

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -692,7 +692,7 @@ assert f(1) == 2
 def f() -> str:
     return 'some string'
 def g() -> str:
-    return 'some\a \v \t \x7f " \n \0string \U0001F40D'
+    return 'some\a \v \t \x7f " \n \0string 🐍'
 def tostr(x: int) -> str:
     return str(x)
 def concat(x: str, y: str) -> str:
@@ -707,7 +707,7 @@ def eq(x: str) -> int:
 [file driver.py]
 from native import f, g, tostr, concat, eq
 assert f() == 'some string'
-assert g() == 'some\a \v \t \x7f " \n \0string \U0001F40D'
+assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
 assert tostr(57) == '57'
 assert concat('foo', 'bar') == 'foobar'
 assert eq('foo') == 0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -692,7 +692,7 @@ assert f(1) == 2
 def f() -> str:
     return 'some string'
 def g() -> str:
-    return 'some\a \v \t \x7f " \n \0string 🐍'
+    return 'some\a \v \t \x7f " \n \0string \U0001F40D'
 def tostr(x: int) -> str:
     return str(x)
 def concat(x: str, y: str) -> str:
@@ -707,7 +707,7 @@ def eq(x: str) -> int:
 [file driver.py]
 from native import f, g, tostr, concat, eq
 assert f() == 'some string'
-assert g() == 'some\a \v \t \x7f " \n \0string 🐍'
+assert g() == 'some\a \v \t \x7f " \n \0string \U0001F40D'
 assert tostr(57) == '57'
 assert concat('foo', 'bar') == 'foobar'
 assert eq('foo') == 0


### PR DESCRIPTION
This adds support for compiling on and for windows using MSVC.

There were two interesting things that needed to be done, and
a handful of uninteresting ones:
 1. As far as I could tell, Windows does not have the equivalents
    to rpath/$ORIGIN/@loader_path that we would need to have the
    dynamic loader automatically load our shared library.
    So instead we do it manually, computing a library
    location and using `LoadLibrary`/`GetProcAddress` to call our init
    functions.
 2. The Windows dynamic loader is less powerful than the Linux/OS X
    loaders, and does not allow you to initialize globals with values
    taken from other libraries. This means that we need to manually
    initialize such globals instead.

I didn't want to fight with running gtest even a little bit, so I
skipped the runtime tests on windows.

This passes the full test suite. I haven't tried mypy yet.

I haven't set up CI for windows yet, but it is important to do soon,
since it will be pretty easy to forget about the dynamic loader
limitations.

@ethanhs, if you want to take a look