### PR TITLE
Implement multi-file compilation

### DIFF
--- a/lib-rt/CPy.c
+++ b/lib-rt/CPy.c
@@ -1,0 +1,20 @@
+#include <stdbool.h>
+#include <Python.h>
+#include <frameobject.h>
+#include <assert.h>
+#include "CPy.h"
+
+// TODO: Currently only the things that *need* to be defined a single time
+// instead of copied into every module live here. This is silly, and most
+// of the code in CPy.h and python_support.h should move here.
+
+struct ExcDummyStruct _CPy_ExcDummyStruct = { PyObject_HEAD_INIT(NULL) };
+PyObject *_CPy_ExcDummy = (PyObject *)&_CPy_ExcDummyStruct;
+
+// Because its dynamic linker is more restricted than linux/OS X,
+// Windows doesn't allow initializing globals with values from
+// other dynamic libraries. This means we need to initialize
+// things at load time.
+void CPy_Init(void) {
+    _CPy_ExcDummyStruct.ob_base.ob_type = &PyBaseObject_Type;
+}

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -848,7 +848,12 @@ static inline bool CPyFloat_Check(PyObject *o) {
 }
 
 static PyObject *CPyLong_FromFloat(PyObject *o) {
-    return PyLong_Check(o) ? o : PyLong_FromDouble(PyFloat_AS_DOUBLE(o));
+    if (PyLong_Check(o)) {
+        CPy_INCREF(o);
+        return o;
+    } else {
+        return PyLong_FromDouble(PyFloat_AS_DOUBLE(o));
+    }
 }
 
 static PyCodeObject *CPy_CreateCodeObject(const char *filename, const char *funcname, int line) {

--- a/lib-rt/CPy.h
+++ b/lib-rt/CPy.h
@@ -903,8 +903,8 @@ static void CPy_AddTraceback(const char *filename, const char *funcname, int lin
 // exception APIs that might want to return NULL pointers instead
 // return properly refcounted pointers to this dummy object.
 struct ExcDummyStruct { PyObject_HEAD };
-static struct ExcDummyStruct _CPy_ExcDummyStruct = { PyObject_HEAD_INIT(NULL) };
-static PyObject *_CPy_ExcDummy = (PyObject *)&_CPy_ExcDummyStruct;
+extern struct ExcDummyStruct _CPy_ExcDummyStruct;
+extern PyObject *_CPy_ExcDummy;
 
 static inline void _CPy_ToDummy(PyObject **p) {
     if (*p == NULL) {
@@ -1020,13 +1020,8 @@ static void CPy_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_t
     _CPy_ToNone(p_traceback);
 }
 
-// Because its dynamic linker is more restricted than linux/OS X,
-// Windows doesn't allow initializing globals with values from
-// other dynamic libraries. This means we need to initialize
-// things at load time.
-static void CPy_Init(void) {
-    _CPy_ExcDummyStruct.ob_base.ob_type = &PyBaseObject_Type;
-}
+void CPy_Init(void);
+
 
 #ifdef __cplusplus
 }

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -227,7 +227,7 @@ def include_dir() -> str:
 
 
 def generate_c(sources: List[BuildSource], options: Options,
-               shared_lib_name: Optional[str]) -> Tuple[str, str]:
+               shared_lib_name: Optional[str]) -> Tuple[List[Tuple[str, str]], str]:
     """Drive the actual core compilation step.
 
     Returns the C source code and (for debugging) the pretty printed IR.
@@ -257,7 +257,7 @@ def generate_c(sources: List[BuildSource], options: Options,
 
 def build_using_shared_lib(sources: List[BuildSource],
                            lib_name: str,
-                           cfile: str,
+                           cfiles: List[str],
                            build_dir: str,
                            extra_compile_args: List[str],
                            ) -> List[MypycifyExtension]:
@@ -275,7 +275,7 @@ def build_using_shared_lib(sources: List[BuildSource],
     shared_lib = MypycifyExtension(
         'lib' + lib_name,
         is_mypyc_shared=True,
-        sources=[cfile],
+        sources=cfiles,
         include_dirs=[include_dir()],
         extra_compile_args=extra_compile_args,
     )
@@ -302,7 +302,7 @@ def build_using_shared_lib(sources: List[BuildSource],
 
 
 def build_single_module(sources: List[BuildSource],
-                        cfile: str,
+                        cfiles: List[str],
                         extra_compile_args: List[str],
                         ) -> List[MypycifyExtension]:
     """Produce the list of extension modules for a standalone extension.
@@ -311,7 +311,7 @@ def build_single_module(sources: List[BuildSource],
     """
     return [MypycifyExtension(
         sources[0].module,
-        sources=[cfile],
+        sources=cfiles,
         include_dirs=[include_dir()],
         extra_compile_args=extra_compile_args,
     )]
@@ -356,7 +356,6 @@ def mypycify(paths: List[str],
     # of the modules are in package. (Because I didn't want to fuss
     # around with making the single module code handle packages.)
     use_shared_lib = len(sources) > 1 or any('.' in x.module for x in sources)
-    cfile = os.path.join(build_dir, '__native.c')
 
     lib_name = shared_lib_name([source.module for source in sources]) if use_shared_lib else None
 
@@ -364,12 +363,18 @@ def mypycify(paths: List[str],
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        ctext, ops_text = generate_c(sources, options, lib_name)
+        cfiles, ops_text = generate_c(sources, options, lib_name)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)
-        with open(cfile, 'w', encoding='utf-8') as f:
-            f.write(ctext)
+        cfilenames = []
+        for cfile, ctext in cfiles:
+            cfile = os.path.join(build_dir, cfile)
+            with open(cfile, 'w', encoding='utf-8') as f:
+                f.write(ctext)
+            cfilenames.append(cfile)
+    else:
+        cfilenames = glob.glob(os.path.join(build_dir, '*.c'))
 
     cflags = []  # type: List[str]
     if compiler.compiler_type == 'unix':
@@ -393,9 +398,9 @@ def mypycify(paths: List[str],
 
     if use_shared_lib:
         assert lib_name
-        extensions = build_using_shared_lib(sources, lib_name, cfile, build_dir, cflags)
+        extensions = build_using_shared_lib(sources, lib_name, cfilenames, build_dir, cflags)
     else:
-        extensions = build_single_module(sources, cfile, cflags)
+        extensions = build_single_module(sources, cfilenames, cflags)
 
     return extensions
 

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -228,6 +228,7 @@ def include_dir() -> str:
 
 
 def generate_c(sources: List[BuildSource], options: Options,
+               multi_file: bool,
                shared_lib_name: Optional[str]) -> Tuple[List[Tuple[str, str]], str]:
     """Drive the actual core compilation step.
 
@@ -248,7 +249,8 @@ def generate_c(sources: List[BuildSource], options: Options,
     print("Parsed and typechecked in {:.3f}s".format(t1 - t0))
 
     ops = []  # type: List[str]
-    ctext = emitmodule.compile_modules_to_c(result, module_names, shared_lib_name, ops=ops)
+    ctext = emitmodule.compile_modules_to_c(result, module_names, shared_lib_name, multi_file,
+                                            ops=ops)
 
     t2 = time.time()
     print("Compiled to C in {:.3f}s".format(t2 - t1))
@@ -321,6 +323,7 @@ def build_single_module(sources: List[BuildSource],
 def mypycify(paths: List[str],
              mypy_options: Optional[List[str]] = None,
              opt_level: str = '3',
+             multi_file: bool = False,
              skip_cgen: bool = False) -> List[MypycifyExtension]:
     """Main entry point to building using mypyc.
 
@@ -364,7 +367,7 @@ def mypycify(paths: List[str],
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        cfiles, ops_text = generate_c(sources, options, lib_name)
+        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -26,6 +26,7 @@ import os.path
 import subprocess
 import hashlib
 import time
+import shutil
 
 from typing import List, Tuple, Any, Optional, Union, Dict, cast
 MYPY = False
@@ -372,7 +373,8 @@ def mypycify(paths: List[str],
             cfile = os.path.join(build_dir, cfile)
             with open(cfile, 'w', encoding='utf-8') as f:
                 f.write(ctext)
-            cfilenames.append(cfile)
+            if os.path.splitext(cfile)[1] == '.c':
+                cfilenames.append(cfile)
     else:
         cfilenames = glob.glob(os.path.join(build_dir, '*.c'))
 
@@ -395,6 +397,11 @@ def mypycify(paths: List[str],
             '/wd4101',  # unreferenced local variable
             '/wd4146',  # negating unsigned int
         ]
+
+    # Copy the runtime library in
+    rt_file = os.path.join(build_dir, 'CPy.c')
+    shutil.copyfile(os.path.join(include_dir(), 'CPy.c'), rt_file)
+    cfilenames.append(rt_file)
 
     if use_shared_lib:
         assert lib_name

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -34,7 +34,7 @@ class EmitterContext:
         # Map from tuple types to unique ids for them
         self.tuple_ids = {}  # type: Dict[RTuple, str]
 
-        # The two maps below are used for generating declarations or
+        # The map below is used for generating declarations and
         # definitions at the top of the C file. The main idea is that they can
         # be generated at any time during the emit phase.
 
@@ -42,11 +42,6 @@ class EmitterContext:
         # used for declaring structs and the key corresponds to the name of the struct.
         # The declaration contains the body of the struct.
         self.declarations = OrderedDict()  # type: Dict[str, HeaderDeclaration]
-
-        # A map from C identifier to code that defined the C identifier. This
-        # is similar to to 'declarations', but these may appear after the
-        # declarations in the generated code.
-        self.statics = OrderedDict()  # type: Dict[str, str]
 
 
 class Emitter:
@@ -205,11 +200,11 @@ class Emitter:
         context = self.context
         id = self.tuple_unique_id(rtuple)
         name = 'tuple_undefined_' + id
-        if name not in context.statics:
+        if name not in context.declarations:
             struct_name = self.tuple_struct_name(rtuple)
             values = self.tuple_undefined_value_helper(rtuple)
             init = 'struct {} {} = {{ {} }};'.format(struct_name, name, ''.join(values))
-            context.statics[name] = init
+            context.declarations[name] = HeaderDeclaration(set([struct_name]), [init])
         return name
 
     def tuple_undefined_value_helper(self, rtuple: RTuple) -> List[str]:

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -19,9 +19,11 @@ from mypyc.sametype import is_same_type
 
 
 class HeaderDeclaration:
-    def __init__(self, dependencies: Set[str], body: List[str]) -> None:
+    def __init__(self,
+                 dependencies: Set[str], decl: List[str], defn: Optional[List[str]]) -> None:
         self.dependencies = dependencies
-        self.body = body
+        self.decl = decl
+        self.defn = defn
 
 
 class EmitterContext:
@@ -203,8 +205,10 @@ class Emitter:
         if name not in context.declarations:
             struct_name = self.tuple_struct_name(rtuple)
             values = self.tuple_undefined_value_helper(rtuple)
-            init = 'struct {} {} = {{ {} }};'.format(struct_name, name, ''.join(values))
-            context.declarations[name] = HeaderDeclaration(set([struct_name]), [init])
+            var = 'struct {} {}'.format(struct_name, name)
+            decl = '{};'.format(var)
+            init = '{} = {{ {} }};'.format(var, ''.join(values))
+            context.declarations[name] = HeaderDeclaration(set([struct_name]), [decl], [init])
         return name
 
     def tuple_undefined_value_helper(self, rtuple: RTuple) -> List[str]:
@@ -237,6 +241,7 @@ class Emitter:
             self.context.declarations[struct_name] = HeaderDeclaration(
                 dependencies,
                 self.tuple_c_declaration(tuple_type),
+                None,
             )
 
     def emit_inc_ref(self, dest: str, rtype: RType) -> None:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -73,6 +73,13 @@ def generate_slots(cl: ClassIR, table: SlotTable, emitter: Emitter) -> Dict[str,
 
 def generate_class_type_decl(cl: ClassIR, emitter: Emitter) -> None:
     emitter.emit_line('static PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
+    emitter.emit_line()
+    generate_object_struct(cl, emitter)
+    emitter.emit_line()
+    declare_native_getters_and_setters(cl, emitter)
+    generate_full = not cl.is_trait and not cl.builtin_base
+    if generate_full:
+        emitter.emit_line('{};'.format(native_function_header(cl.ctor, emitter)))
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
@@ -111,8 +118,6 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     def emit_line() -> None:
         emitter.emit_line()
 
-    emit_line()
-    generate_object_struct(cl, emitter)
     emit_line()
 
     # If the class has a method to initialize default attribute
@@ -222,6 +227,18 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
             for attr, rtype in base.attributes.items():
                 emitter.emit_line('{}{};'.format(emitter.ctype_spaced(rtype), attr))
     emitter.emit_line('}} {};'.format(cl.struct_name(emitter.names)))
+
+
+def declare_native_getters_and_setters(cl: ClassIR,
+                                       emitter: Emitter) -> None:
+    for attr, rtype in cl.attributes.items():
+        emitter.emit_line('{}{}({} *self);'.format(emitter.ctype_spaced(rtype),
+                                                   native_getter_name(cl, attr, emitter.names),
+                                                   cl.struct_name(emitter.names)))
+        emitter.emit_line(
+            'bool {}({} *self, {}value);'.format(native_setter_name(cl, attr, emitter.names),
+                                                 cl.struct_name(emitter.names),
+                                                 emitter.ctype_spaced(rtype)))
 
 
 def generate_native_getters_and_setters(cl: ClassIR,

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -72,7 +72,7 @@ def generate_slots(cl: ClassIR, table: SlotTable, emitter: Emitter) -> Dict[str,
 
 
 def generate_class_type_decl(cl: ClassIR, emitter: Emitter) -> None:
-    emitter.emit_line('static PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
+    emitter.emit_line('PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
     emitter.emit_line()
     generate_object_struct(cl, emitter)
     emitter.emit_line()

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -39,7 +39,7 @@ def native_function_header(fn: FuncDecl, emitter: Emitter) -> str:
     for arg in fn.sig.args:
         args.append('{}{}{}'.format(emitter.ctype_spaced(arg.type), REG_PREFIX, arg.name))
 
-    return 'static {ret_type}{name}({args})'.format(
+    return '{ret_type}{name}({args})'.format(
         ret_type=emitter.ctype_spaced(fn.sig.ret_type),
         name=emitter.native_function_name(fn),
         args=', '.join(args) or 'void')

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -43,7 +43,7 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
 
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          shared_lib_name: Optional[str],
-                         ops: Optional[List[str]] = None) -> str:
+                         ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
 
     # Generate basic IR, with missing exception and refcount handling.
@@ -112,7 +112,7 @@ class ModuleGenerator:
         self.shared_lib_name = shared_lib_name
         self.use_shared_lib = shared_lib_name is not None
 
-    def generate_c_for_modules(self) -> str:
+    def generate_c_for_modules(self) -> List[Tuple[str, str]]:
         emitter = Emitter(self.context)
 
         module_irs = [module_ir for _, module_ir in self.modules]
@@ -186,7 +186,7 @@ class ModuleGenerator:
         for static_def in self.context.statics.values():
             declarations.emit_line(static_def)
 
-        return ''.join(declarations.fragments + emitter.fragments)
+        return [('__native.c', ''.join(declarations.fragments + emitter.fragments))]
 
     def generate_globals_init(self, emitter: Emitter) -> None:
         emitter.emit_lines(

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -380,19 +380,16 @@ class ModuleGenerator:
 
         return result
 
-    def declare_global(self, type_spaced: str, name: str, static: bool = True,
+    def declare_global(self, type_spaced: str, name: str,
                        initializer: Optional[str] = None) -> None:
-        # XXX
-        static_str = ''
-        # static_str = 'static ' if static else ''
         if not initializer:
             defn = None
         else:
-            defn = ['{}{}{} = {};'.format(static_str, type_spaced, name, initializer)]
+            defn = ['{}{}{} = {};'.format(type_spaced, name, initializer)]
         if name not in self.context.declarations:
             self.context.declarations[name] = HeaderDeclaration(
                 set(),
-                ['{}{}{};'.format(static_str, type_spaced, name)],
+                ['{}{}{};'.format(type_spaced, name)],
                 defn,
             )
 

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 
 def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
-    return 'static PyObject *{prefix}{name}(PyObject *self, PyObject *args, PyObject *kw)'.format(
+    return 'PyObject *{prefix}{name}(PyObject *self, PyObject *args, PyObject *kw)'.format(
         prefix=PREFIX,
         name=fn.cname(names))
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -276,7 +276,7 @@ class TestGenerateFunction(unittest.TestCase):
         result = emitter.fragments
         assert_string_arrays_equal(
             [
-                'static CPyTagged CPyDef_myfunc(CPyTagged cpy_r_arg) {\n',
+                'CPyTagged CPyDef_myfunc(CPyTagged cpy_r_arg) {\n',
                 'CPyL0: ;\n',
                 '    return cpy_r_arg;\n',
                 '}\n',
@@ -295,7 +295,7 @@ class TestGenerateFunction(unittest.TestCase):
         result = emitter.fragments
         assert_string_arrays_equal(
             [
-                'static PyObject *CPyDef_myfunc(CPyTagged cpy_r_arg) {\n',
+                'PyObject *CPyDef_myfunc(CPyTagged cpy_r_arg) {\n',
                 '    CPyTagged cpy_r_r0;\n',
                 'CPyL0: ;\n',
                 '    cpy_r_r0 = 10;\n',

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -46,7 +46,7 @@ class TestCompiler(MypycDataSuite):
                     options=options,
                     alt_lib_path=test_temp_dir)
                 cfiles = emitmodule.compile_modules_to_c(
-                    result, module_names=['prog'], multi_file=False, shared_lib_name=None)
+                    result, module_names=['prog'], multi_file=True, shared_lib_name=None)
                 out = []
                 for cfile, ctext in cfiles:
                     out.append('== {} =='.format(cfile))

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -46,7 +46,7 @@ class TestCompiler(MypycDataSuite):
                     options=options,
                     alt_lib_path=test_temp_dir)
                 cfiles = emitmodule.compile_modules_to_c(
-                    result, module_names=['prog'], shared_lib_name=None)
+                    result, module_names=['prog'], multi_file=False, shared_lib_name=None)
                 out = []
                 for cfile, ctext in cfiles:
                     out.append('== {} =='.format(cfile))

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -45,9 +45,12 @@ class TestCompiler(MypycDataSuite):
                     sources=[source],
                     options=options,
                     alt_lib_path=test_temp_dir)
-                ctext = emitmodule.compile_modules_to_c(
+                cfiles = emitmodule.compile_modules_to_c(
                     result, module_names=['prog'], shared_lib_name=None)
-                out = ctext.splitlines()
+                out = []
+                for cfile, ctext in cfiles:
+                    out.append('== {} =='.format(cfile))
+                    out += ctext.splitlines()
             except CompileError as e:
                 out = e.messages
 

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -130,6 +130,7 @@ class TestRun(MypycDataSuite):
                 cfiles = emitmodule.compile_modules_to_c(
                     result,
                     module_names=module_names,
+                    multi_file=True,
                     shared_lib_name=lib_name)
             except CompileError as e:
                 for line in e.messages:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -127,7 +127,7 @@ class TestRun(MypycDataSuite):
                     sources=sources,
                     options=options,
                     alt_lib_path='.')
-                ctext = emitmodule.compile_modules_to_c(
+                cfiles = emitmodule.compile_modules_to_c(
                     result,
                     module_names=module_names,
                     shared_lib_name=lib_name)
@@ -136,9 +136,9 @@ class TestRun(MypycDataSuite):
                     print(line)
                 assert False, 'Compile error'
 
-            cpath = os.path.abspath(os.path.join(workdir, '__native.c'))
-            with open(cpath, 'w', encoding='utf-8') as f:
-                f.write(ctext)
+            for cfile, ctext in cfiles:
+                with open(os.path.join(workdir, cfile), 'w', encoding='utf-8') as f:
+                    f.write(ctext)
 
             setup_file = os.path.abspath(os.path.join(workdir, 'setup.py'))
             with open(setup_file, 'w') as f:
@@ -149,7 +149,7 @@ class TestRun(MypycDataSuite):
             # that the file is there.
             suffix = 'pyd' if sys.platform == 'win32' else 'so'
             if not glob.glob('native.*.{}'.format(suffix)):
-                show_c(ctext)
+                show_c(cfiles)
                 assert False, "Compilation failed"
 
             for p in to_delete:
@@ -178,7 +178,7 @@ class TestRun(MypycDataSuite):
             output = output.decode('utf8')
             outlines = output.splitlines()
 
-            show_c(ctext)
+            show_c(cfiles)
             if proc.returncode != 0:
                 print()
                 print('*** Exit status: %d' % proc.returncode)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -4,7 +4,7 @@ import contextlib
 import os.path
 import re
 import shutil
-from typing import List, Callable, Iterator, Optional
+from typing import List, Callable, Iterator, Optional, Tuple
 
 from mypy import build
 from mypy.errors import CompileError
@@ -173,7 +173,9 @@ def heading(text: str) -> None:
     print('=' * 20 + ' ' + text + ' ' + '=' * 20)
 
 
-def show_c(ctext: str) -> None:
+def show_c(cfiles: List[Tuple[str, str]]) -> None:
     heading('Generated C')
-    print_with_line_numbers(ctext)
+    for cfile, ctext in cfiles:
+        print('== {} =='.format(cfile))
+        print_with_line_numbers(ctext)
     heading('End C')

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -44,13 +44,13 @@ PyMODINIT_FUNC PyInit_prog(void)
     return CPyStatic_module_internal;
 }
 
-static CPyTagged CPyDef_f(CPyTagged cpy_r_x) {
+CPyTagged CPyDef_f(CPyTagged cpy_r_x) {
 CPyL0: ;
     CPyTagged_IncRef(cpy_r_x);
     return cpy_r_x;
 }
 
-static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw) {
+PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw) {
     static char *kwlist[] = {"x", 0};
     PyObject *obj_x;
     if (!PyArg_ParseTupleAndKeywords(args, kw, "O:f", kwlist, &obj_x)) {
@@ -71,7 +71,7 @@ static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw) {
     return retbox;
 }
 
-static char CPyDef___top_level__(void) {
+char CPyDef___top_level__(void) {
     PyObject *cpy_r_r0;
     PyObject *cpy_r_r1;
     char cpy_r_r2;
@@ -108,7 +108,7 @@ CPyL4: ;
     return cpy_r_r6;
 }
 
-static int CPyGlobalsInit(void)
+int CPyGlobalsInit(void)
 {
     static int is_initialized = 0;
     if (is_initialized) return 0;
@@ -122,24 +122,24 @@ static int CPyGlobalsInit(void)
     is_initialized = 1;
     return 0;
 }
-static CPyModule *CPyStatic_module_internal = NULL;
-static CPyModule *CPyStatic_builtins_module_internal = NULL;
+CPyModule *CPyStatic_module_internal = NULL;
+CPyModule *CPyStatic_builtins_module_internal = NULL;
 
 == __native.h ==
 #include <Python.h>
 #include <CPy.h>
 
-static int CPyGlobalsInit(void);
+int CPyGlobalsInit(void);
 
-static PyObject *CPyStatic_unicode_0;
-static CPyModule *CPyStatic_module_internal;
-static CPyModule *CPyStatic_module;
-static PyObject *CPyStatic_globals;
-static CPyModule *CPyStatic_builtins_module_internal;
-static CPyModule *CPyStatic_builtins_module;
-static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
-static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
-static char CPyDef___top_level__(void);
+PyObject *CPyStatic_unicode_0;
+CPyModule *CPyStatic_module_internal;
+CPyModule *CPyStatic_module;
+PyObject *CPyStatic_globals;
+CPyModule *CPyStatic_builtins_module_internal;
+CPyModule *CPyStatic_builtins_module;
+CPyTagged CPyDef_f(CPyTagged cpy_r_x);
+PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
+char CPyDef___top_level__(void);
 
 [case testError]
 def f(x: List[int]) -> None: pass

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -5,6 +5,7 @@
 def f(x: int) -> int:
     return x
 [out]
+== __native.c ==
 #include <Python.h>
 #include <CPy.h>
 
@@ -21,7 +22,7 @@ static int CPyGlobalsInit(void)
 {
     static int is_initialized = 0;
     if (is_initialized) return 0;
-    
+
     CPy_Init();
     CPyStatic_module = Py_None;
     CPyStatic_builtins_module = Py_None;

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -6,33 +6,7 @@ def f(x: int) -> int:
     return x
 [out]
 == __native.c ==
-#include <Python.h>
-#include <CPy.h>
-
-static CPyModule *CPyStatic_module_internal = NULL;
-static CPyModule *CPyStatic_module;
-static PyObject *CPyStatic_globals;
-static CPyModule *CPyStatic_builtins_module_internal = NULL;
-static CPyModule *CPyStatic_builtins_module;
-static PyObject *CPyStatic_unicode_0;
-static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
-static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
-static char CPyDef___top_level__(void);
-static int CPyGlobalsInit(void)
-{
-    static int is_initialized = 0;
-    if (is_initialized) return 0;
-
-    CPy_Init();
-    CPyStatic_module = Py_None;
-    CPyStatic_builtins_module = Py_None;
-    CPyStatic_unicode_0 = PyUnicode_FromStringAndSize("builtins", 8);
-    if (unlikely(CPyStatic_unicode_0 == NULL))
-        return -1;
-    is_initialized = 1;
-    return 0;
-}
-
+#include "__native.h"
 static PyMethodDef module_methods[] = {
     {"f", (PyCFunction)CPyPy_f, METH_VARARGS | METH_KEYWORDS, NULL /* docstring */},
     {NULL, NULL, 0, NULL}
@@ -133,6 +107,39 @@ CPyL4: ;
     cpy_r_r6 = 2;
     return cpy_r_r6;
 }
+
+static int CPyGlobalsInit(void)
+{
+    static int is_initialized = 0;
+    if (is_initialized) return 0;
+    
+    CPy_Init();
+    CPyStatic_module = Py_None;
+    CPyStatic_builtins_module = Py_None;
+    CPyStatic_unicode_0 = PyUnicode_FromStringAndSize("builtins", 8);
+    if (unlikely(CPyStatic_unicode_0 == NULL))
+        return -1;
+    is_initialized = 1;
+    return 0;
+}
+
+== __native.h ==
+#include <Python.h>
+#include <CPy.h>
+
+static int CPyGlobalsInit(void);
+
+/* decls */
+static PyObject *CPyStatic_unicode_0;
+static CPyModule *CPyStatic_module_internal = NULL;
+static CPyModule *CPyStatic_module;
+static PyObject *CPyStatic_globals;
+static CPyModule *CPyStatic_builtins_module_internal = NULL;
+static CPyModule *CPyStatic_builtins_module;
+/* not decls */
+static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
+static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
+static char CPyDef___top_level__(void);
 
 [case testError]
 def f(x: List[int]) -> None: pass

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -122,6 +122,8 @@ static int CPyGlobalsInit(void)
     is_initialized = 1;
     return 0;
 }
+static CPyModule *CPyStatic_module_internal = NULL;
+static CPyModule *CPyStatic_builtins_module_internal = NULL;
 
 == __native.h ==
 #include <Python.h>
@@ -129,14 +131,12 @@ static int CPyGlobalsInit(void)
 
 static int CPyGlobalsInit(void);
 
-/* decls */
 static PyObject *CPyStatic_unicode_0;
-static CPyModule *CPyStatic_module_internal = NULL;
+static CPyModule *CPyStatic_module_internal;
 static CPyModule *CPyStatic_module;
 static PyObject *CPyStatic_globals;
-static CPyModule *CPyStatic_builtins_module_internal = NULL;
+static CPyModule *CPyStatic_builtins_module_internal;
 static CPyModule *CPyStatic_builtins_module;
-/* not decls */
 static CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 static PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
 static char CPyDef___top_level__(void);

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -218,18 +218,26 @@ Traceback (most recent call last):
 IndexError: list assignment index out of range
 
 [case testMultiModuleCycle]
+if False:
+    from typing import Final
 import other
 
+x = int('0')  # type: Final
+
 def f1() -> int:
-    return other.f2()
+    return other.f2() + other.x
 
 def f3() -> int:
     return 5
 [file other.py]
+if False:
+    from typing import Final
 import native
 
+x = int('0')  # type: Final
+
 def f2() -> int:
-    return native.f3()
+    return native.f3() + native.x
 [file driver.py]
 from native import f1
 assert f1() == 5


### PR DESCRIPTION
This implements an initial version of multi-file compilation. Each module is
turned into its own .c file. A shared `__native.c` contains the globals initialization
and global definitions.

The major changes needed to support this are:
1. Declarations used by multiple files are now all collected into a single
    header file (which is 27kloc for mypy). 
2. Most of the order dependence in the code needed to be removed,
    so that different modules could be untangled.
3. This meant adding more forward declarations of things. `HeaderDeclaration`
    was generalized to contain both a declaration (that goes into the shared header)
    and an optional definition (that goes into a shared `.c` file)
4. The runtime finally needs its own `.c` file to prevent duplication of data structures
    it uses. As a TODO, more stuff should be moved into it from the header.

It unfortunately doesn't really seem to help yet. Compilation on Linux with clang is made
slightly *slower* (though that could change if we made it parallelizable), while it seems to
not really matter on Windows, since distutils is configured
to use Link Time Code Generation (this might be changeable, but there also seemed to be
complicated reasons for this when I looked into it).

Initial numbers showed a slowdown (like 5%), but I haven't dug into it too deeply yet.

I am inclined to merge this PR anyways, though, even if we don't turn on multi-file by
default. The abstractions for generating multiple files are probably good, and I think
most of the changes needed to make it work are also good.

Currently this PR turns on multi file mode for `test_run` but leaves it off by default.
Not sure if that is the right approach.