### PR TITLE
Report errors instead of tripping assertions

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -229,7 +229,8 @@ def include_dir() -> str:
 
 def generate_c(sources: List[BuildSource], options: Options,
                multi_file: bool,
-               shared_lib_name: Optional[str]) -> Tuple[List[Tuple[str, str]], str]:
+               shared_lib_name: Optional[str],
+               verbose: bool = False) -> Tuple[List[Tuple[str, str]], str]:
     """Drive the actual core compilation step.
 
     Returns the C source code and (for debugging) the pretty printed IR.
@@ -246,14 +247,16 @@ def generate_c(sources: List[BuildSource], options: Options,
         fail('Typechecking failure')
 
     t1 = time.time()
-    print("Parsed and typechecked in {:.3f}s".format(t1 - t0))
+    if verbose:
+        print("Parsed and typechecked in {:.3f}s".format(t1 - t0))
 
     ops = []  # type: List[str]
     ctext = emitmodule.compile_modules_to_c(result, module_names, shared_lib_name, multi_file,
                                             ops=ops)
 
     t2 = time.time()
-    print("Compiled to C in {:.3f}s".format(t2 - t1))
+    if verbose:
+        print("Compiled to C in {:.3f}s".format(t2 - t1))
 
     return ctext, '\n'.join(ops)
 
@@ -324,7 +327,8 @@ def mypycify(paths: List[str],
              mypy_options: Optional[List[str]] = None,
              opt_level: str = '3',
              multi_file: bool = False,
-             skip_cgen: bool = False) -> List[MypycifyExtension]:
+             skip_cgen: bool = False,
+             verbose: bool = False) -> List[MypycifyExtension]:
     """Main entry point to building using mypyc.
 
     This produces a list of Extension objects that should be passed as the
@@ -367,7 +371,7 @@ def mypycify(paths: List[str],
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name)
+        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name, verbose)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -53,7 +53,6 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
     file_nodes = [result.files[name] for name in module_names]
     literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types)
     if errors > 0:
-        print("Aborting due to {} error{}".format(errors, "s" if errors > 1 else ""))
         sys.exit(1)
     # Insert uninit checks.
     for _, module in modules:

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -1,5 +1,7 @@
 """Generate C code for a Python C extension module from Python source code."""
 
+import sys
+
 from collections import OrderedDict
 from typing import List, Tuple, Dict, Iterable, Set, TypeVar, Optional
 
@@ -49,7 +51,10 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
 
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
-    literals, modules = genops.build_ir(file_nodes, result.graph, result.types)
+    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types)
+    if errors > 0:
+        print("Aborting due to {} error{}".format(errors, "s" if errors > 1 else ""))
+        sys.exit(1)
     # Insert uninit checks.
     for _, module in modules:
         for fn in module.functions:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -14,7 +14,7 @@ It would be translated to something that conceptually looks like this:
    return r3
 """
 from typing import (
-    Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, cast, overload,
+    Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, NoReturn, cast, overload,
 )
 MYPY = False
 if MYPY:
@@ -99,11 +99,30 @@ from mypyc.crash import catch_errors
 GenFunc = Callable[[], None]
 
 
+class UnsupportedException(Exception):
+    pass
+
+
+class Errors:
+    def __init__(self) -> None:
+        self.num_errors = 0
+        self.num_warnings = 0
+
+    def error(self, msg: str, path: str, line: int) -> None:
+        print('{}:{}: error: {}'.format(path, line, msg))
+        self.num_errors += 1
+
+    def warning(self, msg: str, path: str, line: int) -> None:
+        print('{}:{}: warning: {}'.format(path, line, msg))
+        self.num_warnings += 1
+
+
 def build_ir(modules: List[MypyFile],
              graph: Graph,
-             types: Dict[Expression, Type]) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]]]:
+             types: Dict[Expression, Type]) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]], int]:
     result = []
     mapper = Mapper()
+    errors = Errors()
 
     # Collect all classes defined in the compilation unit.
     classes = []
@@ -121,7 +140,7 @@ def build_ir(modules: List[MypyFile],
     # Populate structural information in class IR.
     for module, cdef in classes:
         with catch_errors(module.path, cdef.line):
-            prepare_class_def(module.fullname(), cdef, mapper)
+            prepare_class_def(module.path, module.fullname(), cdef, errors, mapper)
 
     # Collect all the functions also. We collect from the symbol table
     # so that we can easily pick out the right copy of a function that
@@ -146,7 +165,7 @@ def build_ir(modules: List[MypyFile],
         module.accept(pbv)
 
         # Second pass.
-        builder = IRBuilder(types, graph, mapper, module_names, pbv)
+        builder = IRBuilder(types, graph, errors, mapper, module_names, pbv)
         builder.visit_mypy_file(module)
         module_ir = ModuleIR(
             builder.imports,
@@ -161,7 +180,7 @@ def build_ir(modules: List[MypyFile],
     for cir in class_irs:
         compute_vtable(cir)
 
-    return mapper.literals, result
+    return mapper.literals, result, errors.num_errors
 
 
 def is_trait(cdef: ClassDef) -> bool:
@@ -384,7 +403,16 @@ def prepare_method_def(ir: ClassIR, module_name: str, cdef: ClassDef, mapper: Ma
             ir.property_types[node.name()] = decl.sig.ret_type
 
 
-def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
+def prepare_class_def(path: str, module_name: str, cdef: ClassDef,
+                      errors: Errors, mapper: Mapper) -> None:
+    # The metaclass chain for GenericMeta all works, but in general they don't
+    if (cdef.info.metaclass_type and cdef.info.metaclass_type.type.fullname() not in (
+            'abc.ABCMeta', 'typing.TypingMeta', 'typing.GenericMeta')):
+        errors.error("Metaclasses are not supported", path, cdef.line)
+    if any(not (isinstance(d, NameExpr) and d.fullname == 'mypy_extensions.trait')
+           for d in cdef.decorators):
+        errors.error("Class decorators are not supported", path, cdef.line)
+
     ir = mapper.type_to_ir[cdef.info]
     info = cdef.info
     for name, node in info.names.items():
@@ -398,12 +426,21 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
             assert node.node.impl
             prepare_method_def(ir, module_name, cdef, mapper, node.node.impl)
 
-    # Special case exceptions and dicts
-    # XXX: How do we handle *other* things??
-    if info.bases and any(cls.fullname() == 'builtins.Exception' for cls in info.mro):
-        ir.builtin_base = 'PyBaseExceptionObject'
-    if info.bases and any(cls.fullname() == 'builtins.dict' for cls in info.mro):
-        ir.builtin_base = 'PyDictObject'
+    # Check for subclassing from builtin types
+    for cls in info.mro:
+        # Special case exceptions and dicts
+        # XXX: How do we handle *other* things??
+        if cls.fullname() == 'builtins.Exception':
+            # don't do anything for Exception (we'll do something for BaseException)
+            pass
+        elif cls.fullname() == 'builtins.BaseException':
+            ir.builtin_base = 'PyBaseExceptionObject'
+        elif cls.fullname() == 'builtins.dict':
+            ir.builtin_base = 'PyDictObject'
+        elif cls.fullname() == 'builtins.object':
+            pass
+        elif cls.fullname().startswith('builtins.'):
+            errors.error("Inheriting from most builtin types is unimplemented", path, cdef.line)
 
     if ir.builtin_base:
         ir.attributes.clear()
@@ -419,7 +456,8 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
     # Set up the parent class
     bases = [mapper.type_to_ir[base.type] for base in info.bases
              if base.type in mapper.type_to_ir]
-    assert all(c.is_trait for c in bases[1:]), "Non trait bases must be first"
+    if not all(c.is_trait for c in bases[1:]):
+        errors.error("Non-trait bases appear first in parent list", path, cdef.line)
     ir.traits = [c for c in bases if c.is_trait]
 
     mro = []
@@ -441,8 +479,8 @@ def prepare_class_def(module_name: str, cdef: ClassDef, mapper: Mapper) -> None:
     base_idx = 1 if not ir.is_trait else 0
     if len(base_mro) > base_idx:
         ir.base = base_mro[base_idx]
-    assert all(base_mro[i].base == base_mro[i + 1] for i in range(len(base_mro) - 1)), (
-        "non-trait MRO must be linear")
+    if not all(base_mro[i].base == base_mro[i + 1] for i in range(len(base_mro) - 1)):
+        errors.error("Non-trait MRO must be linear", path, cdef.line)
     ir.mro = mro
     ir.base_mro = base_mro
 
@@ -627,23 +665,23 @@ class NonlocalControl:
     try/except blocks).
     """
     @abstractmethod
-    def gen_break(self, builder: 'IRBuilder') -> None: pass
+    def gen_break(self, builder: 'IRBuilder', line: int) -> None: pass
 
     @abstractmethod
-    def gen_continue(self, builder: 'IRBuilder') -> None: pass
+    def gen_continue(self, builder: 'IRBuilder', line: int) -> None: pass
 
     @abstractmethod
-    def gen_return(self, builder: 'IRBuilder', value: Value) -> None: pass
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None: pass
 
 
 class BaseNonlocalControl(NonlocalControl):
-    def gen_break(self, builder: 'IRBuilder') -> None:
+    def gen_break(self, builder: 'IRBuilder', line: int) -> None:
         assert False, "break outside of loop"
 
-    def gen_continue(self, builder: 'IRBuilder') -> None:
+    def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
         assert False, "continue outside of loop"
 
-    def gen_return(self, builder: 'IRBuilder', value: Value) -> None:
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
         builder.add(Return(value))
 
 
@@ -653,35 +691,35 @@ class CleanupNonlocalControl(NonlocalControl):
         self.outer = outer
 
     @abstractmethod
-    def gen_cleanup(self, builder: 'IRBuilder') -> None: ...
+    def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None: ...
 
-    def gen_break(self, builder: 'IRBuilder') -> None:
-        self.gen_cleanup(builder)
-        self.outer.gen_break(builder)
+    def gen_break(self, builder: 'IRBuilder', line: int) -> None:
+        self.gen_cleanup(builder, line)
+        self.outer.gen_break(builder, line)
 
-    def gen_continue(self, builder: 'IRBuilder') -> None:
-        self.gen_cleanup(builder)
-        self.outer.gen_continue(builder)
+    def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
+        self.gen_cleanup(builder, line)
+        self.outer.gen_continue(builder, line)
 
-    def gen_return(self, builder: 'IRBuilder', value: Value) -> None:
-        self.gen_cleanup(builder)
-        self.outer.gen_return(builder, value)
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
+        self.gen_cleanup(builder, line)
+        self.outer.gen_return(builder, value, line)
 
 
 class GeneratorNonlocalControl(BaseNonlocalControl):
-    def gen_return(self, builder: 'IRBuilder', value: Value) -> None:
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
         # Assign an invalid next label number so that the next time __next__ is called, we jump to
         # the case in which StopIteration is raised.
         builder.assign(builder.fn_info.generator_class.next_label_target,
                        builder.add(LoadInt(-1)),
-                       builder.fn_info.fitem.line)
+                       line)
         # Raise a StopIteration containing a field for the value that should be returned. Before
         # doing so, create a new block without an error handler set so that the implicitly thrown
         # StopIteration isn't caught by except blocks inside of the generator function.
         builder.error_handlers.append(None)
         builder.goto_new_block()
         builder.add(RaiseStandardError(RaiseStandardError.STOP_ITERATION, value,
-                                       builder.fn_info.fitem.line))
+                                       line))
         builder.add(Unreachable())
         builder.error_handlers.pop()
 
@@ -690,6 +728,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def __init__(self,
                  types: Dict[Expression, Type],
                  graph: Graph,
+                 errors: Errors,
                  mapper: Mapper,
                  modules: List[str],
                  pbv: PreBuildVisitor) -> None:
@@ -731,6 +770,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # Stack of except handler entry blocks
         self.error_handlers = [None]  # type: List[Optional[BasicBlock]]
 
+        self.errors = errors
         self.mapper = mapper
         self.imports = []  # type: List[str]
 
@@ -866,8 +906,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             lvalue = stmt.lvalues[0]
             assert isinstance(lvalue, NameExpr)
             if not self.is_approximately_constant(stmt.rvalue):
-                print('{}:{}: Warning: unsupported default attribute value'.format(
-                    self.module_path, stmt.rvalue.line))
+                self.warning('Unsupported default attribute value', stmt.rvalue.line)
 
             # If the attribute is initialized to None and type isn't optional,
             # don't initialize it to anything.
@@ -904,9 +943,15 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 # Variable declaration with no body
                 if isinstance(stmt.rvalue, TempNode):
                     continue
-                assert len(stmt.lvalues) == 1
+
+                if len(stmt.lvalues) != 1:
+                    self.error("Multiple assignment in class bodies not supported", stmt.line)
+                    continue
                 lvalue = stmt.lvalues[0]
-                assert isinstance(lvalue, NameExpr)
+                if not isinstance(lvalue, NameExpr):
+                    self.error("Only assignment to variables is supported in class bodies",
+                               stmt.line)
+                    continue
                 # Only treat marked class variables as class variables.
                 if not (is_class_var(lvalue) or stmt.is_final_def):
                     continue
@@ -921,8 +966,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 # Docstring. Ignore
                 pass
             else:
-                with self.catch_errors(stmt.line):
-                    assert False, "Unsupported statement in class body"
+                self.error("Unsupported statement in class body", stmt.line)
 
         self.generate_attr_defaults(cdef)
         self.create_ne_from_eq(cdef)
@@ -1016,7 +1060,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         if node.is_mypy_only:
             return
         # TODO support these?
-        assert not node.relative
+        if node.relative:
+            self.error("Relative imports are unimplemented", node.line)
+            return
 
         self.gen_import(node.id, node.line)
         module = self.add(LoadStatic(object_rprimitive, 'module', node.id))
@@ -1163,8 +1209,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         for arg in fitem.arguments:
             if arg.initializer:
                 if not self.is_approximately_constant(arg.initializer):
-                    print('{}:{}: Warning: unsupported default argument value'.format(
-                        self.module_path, arg.initializer.line))
+                    self.warning('Unsupported default argument value', arg.initializer.line)
                 target = self.environment.lookup(arg.variable)
                 assert isinstance(target, AssignmentTargetRegister)
                 self.assign_if_null(target,
@@ -1209,7 +1254,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         | c_obj |   --------------------------+
         +-------+
         """
-        assert not any(kind in (ARG_STAR, ARG_STAR2) for kind in fitem.arg_kinds)
+        if any(kind in (ARG_STAR, ARG_STAR2) for kind in fitem.arg_kinds):
+            self.error('Accepting *args or **kwargs is unimplemented', fitem.line)
 
         func_reg = None  # type: Optional[Value]
 
@@ -1338,7 +1384,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         block = self.blocks[-1][-1]
         if not block.ops or not isinstance(block.ops[-1], ControlOp):
             retval = self.coerce(self.none(), self.ret_types[-1], -1)
-            self.nonlocal_control[-1].gen_return(self, retval)
+            self.nonlocal_control[-1].gen_return(self, retval, self.fn_info.fitem.line)
 
     def add_implicit_unreachable(self) -> None:
         block = self.blocks[-1][-1]
@@ -1367,9 +1413,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         else:
             retval = self.none()
         retval = self.coerce(retval, self.ret_types[-1], stmt.line)
-        self.nonlocal_control[-1].gen_return(self, retval)
+        self.nonlocal_control[-1].gen_return(self, retval, stmt.line)
 
-    def disallow_class_assignments(self, lvalues: List[Lvalue]) -> None:
+    def disallow_class_assignments(self, lvalues: List[Lvalue], line: int) -> None:
         # Some best-effort attempts to disallow assigning to class
         # variables that aren't marked ClassVar, since we blatantly
         # miscompile the interaction between instance and class
@@ -1379,8 +1425,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     and isinstance(lvalue.expr, RefExpr)
                     and isinstance(lvalue.expr.node, TypeInfo)):
                 var = lvalue.expr.node[lvalue.name].node
-                assert not isinstance(var, Var) or var.is_classvar, (
-                    "mypyc only supports assignment to classvars defined as ClassVar")
+                if isinstance(var, Var) and not var.is_classvar:
+                    self.error(
+                        "Only class variables defined as ClassVar can be assigned to",
+                        line)
 
     def non_function_scope(self) -> bool:
         # Currently the stack always has at least two items: dummy and top-level.
@@ -1439,7 +1487,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def visit_assignment_stmt(self, stmt: AssignmentStmt) -> None:
         assert len(stmt.lvalues) >= 1
-        self.disallow_class_assignments(stmt.lvalues)
+        self.disallow_class_assignments(stmt.lvalues, stmt.line)
         lvalue = stmt.lvalues[0]
         if stmt.type and isinstance(stmt.rvalue, TempNode):
             # This is actually a variable annotation without initializer. Don't generate
@@ -1458,7 +1506,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def visit_operator_assignment_stmt(self, stmt: OperatorAssignmentStmt) -> None:
         """Operator assignment statement such as x += 1"""
-        self.disallow_class_assignments([stmt.lvalue])
+        self.disallow_class_assignments([stmt.lvalue], stmt.line)
         target = self.get_assignment_target(stmt.lvalue)
         target_value = self.read(target, stmt.line)
         rreg = self.accept(stmt.rvalue)
@@ -1624,14 +1672,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.continue_block = continue_block
             self.break_block = break_block
 
-        def gen_break(self, builder: 'IRBuilder') -> None:
+        def gen_break(self, builder: 'IRBuilder', line: int) -> None:
             builder.add(Goto(self.break_block))
 
-        def gen_continue(self, builder: 'IRBuilder') -> None:
+        def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
             builder.add(Goto(self.continue_block))
 
-        def gen_return(self, builder: 'IRBuilder', value: Value) -> None:
-            self.outer.gen_return(builder, value)
+        def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
+            self.outer.gen_return(builder, value, line)
 
     def push_loop_stack(self, continue_block: BasicBlock, break_block: BasicBlock) -> None:
         self.nonlocal_control.append(
@@ -1817,7 +1865,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     end_reg = self.accept(expr.args[1])
                 if len(expr.args) == 3:
                     step = self.extract_int(expr.args[2])
-                    assert step, "range() step can't be zero"
+                    assert step is not None
+                    if step == 0:
+                        self.error("range() step can't be zero", expr.args[2].line)
                 else:
                     step = 1
 
@@ -1869,10 +1919,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return for_obj
 
     def visit_break_stmt(self, node: BreakStmt) -> None:
-        self.nonlocal_control[-1].gen_break(self)
+        self.nonlocal_control[-1].gen_break(self, node.line)
 
     def visit_continue_stmt(self, node: ContinueStmt) -> None:
-        self.nonlocal_control[-1].gen_continue(self)
+        self.nonlocal_control[-1].gen_continue(self, node.line)
 
     def visit_unary_expr(self, expr: UnaryExpr) -> Value:
         return self.unary_op(self.accept(expr.expr), expr.op, expr.line)
@@ -2673,7 +2723,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         """First accepts all keys and values, then makes a dict out of them."""
         key_value_pairs = []
         for key_expr, value_expr in expr.items:
-            assert key_expr is not None, "**args in dict expressions unimplemented"
+            if key_expr is None:
+                self.bail("**args in dict expressions is unimplemented", expr.line)
             key = self.accept(key_expr)
             value = self.accept(value_expr)
             key_value_pairs.append((key, value))
@@ -2818,9 +2869,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             super().__init__(outer)
             self.saved = saved
 
-        def gen_cleanup(self, builder: 'IRBuilder') -> None:
-            # Don't bother plumbing a line through because it can't fail
-            builder.primitive_op(restore_exc_info_op, [self.saved], -1)
+        def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
+            builder.primitive_op(restore_exc_info_op, [self.saved], line)
 
     def visit_try_except(self,
                          body: GenFunc,
@@ -2923,13 +2973,13 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.target = target
             self.ret_reg = None  # type: Optional[Register]
 
-        def gen_break(self, builder: 'IRBuilder') -> None:
-            assert False, "unimplemented"
+        def gen_break(self, builder: 'IRBuilder', line: int) -> None:
+            builder.error("break inside try/finally block is unimplemented", line)
 
-        def gen_continue(self, builder: 'IRBuilder') -> None:
-            assert False, "unimplemented"
+        def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
+            builder.error("continue inside try/finally block is unimplemented", line)
 
-        def gen_return(self, builder: 'IRBuilder', value: Value) -> None:
+        def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
             if self.ret_reg is None:
                 self.ret_reg = builder.alloc_temp(builder.ret_types[-1])
 
@@ -2947,7 +2997,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.ret_reg = ret_reg
             self.saved = saved
 
-        def gen_cleanup(self, builder: 'IRBuilder') -> None:
+        def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
             # Do an error branch on the return value register, which
             # may be undefined. This will allow it to be properly
             # decrefed if it is not null. This is kind of a hack.
@@ -2957,11 +3007,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 builder.activate_block(target)
 
             # Restore the old exc_info
-            # Don't bother plumbing a line through because it can't fail
             target, cleanup = BasicBlock(), BasicBlock()
             builder.add(Branch(self.saved, target, cleanup, Branch.IS_ERROR))
             builder.activate_block(cleanup)
-            builder.primitive_op(restore_exc_info_op, [self.saved], -1)
+            builder.primitive_op(restore_exc_info_op, [self.saved], line)
             builder.goto_and_activate(target)
 
     def try_finally_try(self, err_handler: BasicBlock, return_entry: BasicBlock,
@@ -3043,7 +3092,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.add(Branch(ret_reg, rest, return_block, Branch.IS_ERROR))
 
             self.activate_block(return_block)
-            self.nonlocal_control[-1].gen_return(self, ret_reg)
+            self.nonlocal_control[-1].gen_return(self, ret_reg, -1)
 
         # TODO: handle break/continue
         self.activate_block(rest)
@@ -3052,7 +3101,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         # If there was an exception, restore again
         self.activate_block(cleanup_block)
-        finally_control.gen_cleanup(self)
+        finally_control.gen_cleanup(self, -1)
         self.primitive_op(keep_propagating_op, [], NO_TRACEBACK_LINE_NO)
         self.add(Unreachable())
 
@@ -3207,9 +3256,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.add(Unreachable())
         self.activate_block(ok_block)
 
-    def visit_cast_expr(self, o: CastExpr) -> Value:
-        assert False, "CastExpr handled in CallExpr"
-
     def visit_list_comprehension(self, o: ListComprehension) -> Value:
         gen = o.generator
         list_ops = self.primitive_op(new_list_op, [], o.line)
@@ -3247,8 +3293,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return d
 
     def visit_generator_expr(self, o: GeneratorExpr) -> Value:
-        print('{}:{}: Warning: treating generator comprehension as list'.format(
-            self.module_path, o.line))
+        self.warning('Treating generator comprehension as list', o.line)
 
         gen = o
         list_ops = self.primitive_op(new_list_op, [], o.line)
@@ -3303,7 +3348,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 # If the condition is true we'll skip the continue.
                 self.add_bool_branch(cond_val, rest_block, cont_block)
                 self.activate_block(cont_block)
-                self.nonlocal_control[-1].gen_continue(self)
+                self.nonlocal_control[-1].gen_continue(self, cond.line)
                 self.goto_and_activate(rest_block)
 
             if remaining_loop_params:
@@ -3365,11 +3410,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             key = self.load_static_unicode(expr.name)
             self.add(PrimitiveOp([base_reg, key], py_delattr_op, expr.line))
         else:
-            assert False, 'Unsupported del operation'
+            self.error("Unimplemented del operation", expr.line)
 
     def visit_super_expr(self, o: SuperExpr) -> Value:
-        # print('{}:{}: Warning: can not optimize super() expression'.format(
-        #     self.module_path, o.line))
+        # self.warning('can not optimize super() expression', o.line)
         sup_val = self.load_module_attr_by_fullname('builtins.super', o.line)
         if o.call.args:
             args = [self.accept(arg) for arg in o.call.args]
@@ -3408,65 +3452,67 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.primitive_op(ellipsis_op, [], o.line)
 
     # Unimplemented constructs
-    # TODO: some of these are actually things that should never show up,
-    # so properly sort those out.
-
-    def visit__promote_expr(self, o: PromoteExpr) -> Value:
-        raise NotImplementedError
-
     def visit_await_expr(self, o: AwaitExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_backquote_expr(self, o: BackquoteExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_complex_expr(self, o: ComplexExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_enum_call_expr(self, o: EnumCallExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_exec_stmt(self, o: ExecStmt) -> None:
-        raise NotImplementedError
-
-    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_newtype_expr(self, o: NewTypeExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_print_stmt(self, o: PrintStmt) -> None:
-        raise NotImplementedError
-
-    def visit_reveal_expr(self, o: RevealExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_star_expr(self, o: StarExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_temp_node(self, o: TempNode) -> Value:
-        raise NotImplementedError
-
-    def visit_type_alias_expr(self, o: TypeAliasExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_type_application(self, o: TypeApplication) -> Value:
-        raise NotImplementedError
-
-    def visit_type_var_expr(self, o: TypeVarExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_typeddict_expr(self, o: TypedDictExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_unicode_expr(self, o: UnicodeExpr) -> Value:
-        raise NotImplementedError
-
-    def visit_var(self, o: Var) -> None:
-        raise NotImplementedError
+        self.bail("await is unimplemented", o.line)
 
     def visit_yield_from_expr(self, o: YieldFromExpr) -> Value:
-        raise NotImplementedError
+        self.bail("yield from is unimplemented", o.line)
+
+    def visit_complex_expr(self, o: ComplexExpr) -> Value:
+        self.bail("complex literals are unimplemented", o.line)
+
+    def visit_star_expr(self, o: StarExpr) -> Value:
+        self.bail("Star expressions (in non call contexts) are unimplemented", o.line)
+
+    def visit_reveal_expr(self, o: RevealExpr) -> Value:
+        self.bail("reveal_from can't be run", o.line)
+
+    # Unimplemented constructs that shouldn't come up because they are py2 only
+    def visit_backquote_expr(self, o: BackquoteExpr) -> Value:
+        self.bail("Python 2 features are unsupported", o.line)
+
+    def visit_exec_stmt(self, o: ExecStmt) -> None:
+        self.bail("Python 2 features are unsupported", o.line)
+
+    def visit_print_stmt(self, o: PrintStmt) -> None:
+        self.bail("Python 2 features are unsupported", o.line)
+
+    def visit_unicode_expr(self, o: UnicodeExpr) -> Value:
+        self.bail("Python 2 features are unsupported", o.line)
+
+    # Construccts that shouldn't ever show up
+    def visit_enum_call_expr(self, o: EnumCallExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit__promote_expr(self, o: PromoteExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_newtype_expr(self, o: NewTypeExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_temp_node(self, o: TempNode) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_type_alias_expr(self, o: TypeAliasExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_type_application(self, o: TypeApplication) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_type_var_expr(self, o: TypeVarExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_typeddict_expr(self, o: TypedDictExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_var(self, o: Var) -> None:
+        assert False, "can't compile Var; should have been handled already?"
+
+    def visit_cast_expr(self, o: CastExpr) -> Value:
+        assert False, "CastExpr should have been handled in CallExpr"
 
     # Helpers
 
@@ -3552,11 +3598,21 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def accept(self, node: Union[Statement, Expression]) -> Optional[Value]:
         with self.catch_errors(node.line):
             if isinstance(node, Expression):
-                res = node.accept(self)
-                res = self.coerce(res, self.node_type(node), node.line)
+                try:
+                    res = node.accept(self)
+                    res = self.coerce(res, self.node_type(node), node.line)
+                # If we hit an error during compilation, we want to
+                # keep trying, so we can produce more error
+                # messages. Generate a temp of the right type to keep
+                # from causing more downstream trouble.
+                except UnsupportedException:
+                    res = self.alloc_temp(self.node_type(node))
                 return res
             else:
-                node.accept(self)
+                try:
+                    node.accept(self)
+                except UnsupportedException:
+                    pass
                 return None
 
     def alloc_temp(self, type: RType) -> Register:
@@ -4281,3 +4337,19 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     # Lacks a good type because there wasn't a reasonable type in 3.5 :(
     def catch_errors(self, line: int) -> Any:
         return catch_errors(self.module_path, line)
+
+    def warning(self, msg: str, line: int) -> None:
+        self.errors.warning(msg, self.module_path, line)
+
+    def error(self, msg: str, line: int) -> None:
+        self.errors.error(msg, self.module_path, line)
+
+    def bail(self, msg: str, line: int) -> NoReturn:
+        """Reports an error and aborts compilation up until the last accept() call
+
+        (accept() catches the UnsupportedException and keeps on
+        processing. This allows errors to be non-blocking without always
+        needing to write handling for them.
+        """
+        self.error(msg, line)
+        raise UnsupportedException()

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -65,7 +65,7 @@ class TestCommandLine(MypycDataSuite):
 
         # Strip out 'tmp/' from error message paths in the testcase output,
         # due to a mismatch between this test and mypy's test suite.
-        expected = [x.replace('tmp' + os.sep, '') for x in testcase.output]
+        expected = [x.replace('tmp/', '') for x in testcase.output]
 
         # Verify output
         actual = out.decode().splitlines()

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -63,6 +63,10 @@ class TestCommandLine(MypycDataSuite):
             for path in so_paths:
                 os.remove(path)
 
+        # Strip out 'tmp/' from error message paths in the testcase output,
+        # due to a mismatch between this test and mypy's test suite.
+        expected = [x.replace('tmp' + os.sep, '') for x in testcase.output]
+
         # Verify output
         actual = out.decode().splitlines()
-        assert_test_output(testcase, actual, 'Invalid output')
+        assert_test_output(testcase, actual, 'Invalid output', expected=expected)

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -12,6 +12,7 @@ import sys
 
 from mypy.test.data import DataDrivenTestCase
 from mypy.test.config import test_temp_dir
+from mypy.test.helpers import normalize_error_messages
 
 from mypyc.test.testutil import MypycDataSuite, assert_test_output
 
@@ -68,5 +69,5 @@ class TestCommandLine(MypycDataSuite):
         expected = [x.replace('tmp/', '') for x in testcase.output]
 
         # Verify output
-        actual = out.decode().splitlines()
+        actual = normalize_error_messages(out.decode().splitlines())
         assert_test_output(testcase, actual, 'Invalid output', expected=expected)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -95,7 +95,9 @@ def build_ir_for_single_file(input_lines: List[str]) -> List[FuncIR]:
                          alt_lib_path=test_temp_dir)
     if result.errors:
         raise CompileError(result.errors)
-    _, modules = genops.build_ir([result.files['__main__']], result.graph, result.types)
+    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types)
+    assert errors == 0
+
     module = modules[0][1]
     return module.functions
 

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -93,3 +93,66 @@ assert a.f(10) == 100
 [file a.py]
 def f(x: int) -> int:
     return x*x
+
+[case testErrorOutput]
+# cmd: test.py
+
+[file test.py]
+from typing import List, Any
+from typing_extensions import Final
+
+def args(*x: int) -> int:
+    return sum(x)
+
+def foo(x: List[int]) -> List[int]:
+    return [1, 2, *x]
+
+def busted(b: bool) -> None:
+    for i in range(1, 10, 0):
+        try:
+            if i == 5:
+                break
+        finally:
+            print('oops')
+
+print(foo([1,2,3]))
+
+x = [1,2]
+
+class Foo:
+    a, b = (10, 20)
+    x[0] = 10
+    lol = 20
+
+    if 1+1 == 2:
+        x = 10
+
+Foo.lol = 50
+
+print(x)
+del x
+
+def decorator(x: Any) -> Any:
+    return x
+
+class NeverMetaclass(type):
+    pass
+
+@decorator
+class Wrong(metaclass=NeverMetaclass):
+    pass
+
+[out]
+test.py:38: error: Inheriting from most builtin types is unimplemented
+test.py:41: error: Metaclasses are not supported
+test.py:41: error: Class decorators are not supported
+test.py:4: error: Accepting *args or **kwargs is unimplemented
+test.py:8: error: Star expressions (in non call contexts) are unimplemented
+test.py:11: error: range() step can't be zero
+test.py:14: error: break inside try/finally block is unimplemented
+test.py:23: error: Only assignment to variables is supported in class bodies
+test.py:24: error: Only assignment to variables is supported in class bodies
+test.py:27: error: Unsupported statement in class body
+test.py:30: error: Only class variables defined as ClassVar can be assigned to
+test.py:33: error: Unimplemented del operation
+Aborting due to 12 errors

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -95,11 +95,12 @@ def f(x: int) -> int:
     return x*x
 
 [case testErrorOutput]
-# cmd: test.py
+# cmd: test.py foo/__init__.py foo/bar.py
 
 [file test.py]
 from typing import List, Any
 from typing_extensions import Final
+from mypy_extensions import trait
 
 def args(*x: int) -> int:
     return sum(x)
@@ -112,8 +113,12 @@ def busted(b: bool) -> None:
         try:
             if i == 5:
                 break
+            elif i == 4:
+                continue
         finally:
             print('oops')
+    reveal_type(b)  # type: ignore
+    reveal_locals()  # type: ignore
 
 print(foo([1,2,3]))
 
@@ -123,6 +128,8 @@ class Foo:
     a, b = (10, 20)
     x[0] = 10
     lol = 20
+    l = [10]
+    c = d = 50
 
     if 1+1 == 2:
         x = 10
@@ -142,17 +149,72 @@ class NeverMetaclass(type):
 class Wrong(metaclass=NeverMetaclass):
     pass
 
+class Concrete1:
+    pass
+
+@trait
+class Trait1(Concrete1):
+    pass
+
+class Concrete2:
+    pass
+
+@trait
+class Trait2(Concrete2):
+    pass
+
+cmplx = 2+5j
+
+def warning(x: List[int] = []) -> None:
+    pass
+
+# check that concrete bases need to come first and that non-trait MRO must be linear
+class Nope(Trait1, Concrete2):
+    pass
+
+iterator_warning = (i+1 for i in range(10))
+
+d1 = {1: 2}
+d2 = {2: 3, **d1}
+
+async def aio(x: Any) -> Any:
+    await x
+
+def yieldfrom(x: Any) -> Any:
+    yield from x
+
+[file foo/__init__.py]
+x = 20
+
+[file foo/bar.py]
+from . import x
+
+
 [out]
-test.py:38: error: Inheriting from most builtin types is unimplemented
-test.py:41: error: Metaclasses are not supported
-test.py:41: error: Class decorators are not supported
-test.py:4: error: Accepting *args or **kwargs is unimplemented
-test.py:8: error: Star expressions (in non call contexts) are unimplemented
-test.py:11: error: range() step can't be zero
-test.py:14: error: break inside try/finally block is unimplemented
-test.py:23: error: Only assignment to variables is supported in class bodies
-test.py:24: error: Only assignment to variables is supported in class bodies
-test.py:27: error: Unsupported statement in class body
-test.py:30: error: Only class variables defined as ClassVar can be assigned to
-test.py:33: error: Unimplemented del operation
-Aborting due to 12 errors
+test.py:45: error: Inheriting from most builtin types is unimplemented
+test.py:48: error: Metaclasses are not supported
+test.py:48: error: Class decorators are not supported
+test.py:72: error: Non-trait bases appear first in parent list
+test.py:72: error: Non-trait MRO must be linear
+test.py:5: error: Accepting *args or **kwargs is unimplemented
+test.py:9: error: Star expressions (in non call contexts) are unimplemented
+test.py:12: error: range() step can't be zero
+test.py:15: error: break inside try/finally block is unimplemented
+test.py:17: error: continue inside try/finally block is unimplemented
+test.py:28: error: Only assignment to variables is supported in class bodies
+test.py:29: error: Only assignment to variables is supported in class bodies
+test.py:32: error: Multiple assignment in class bodies not supported
+test.py:34: error: Unsupported statement in class body
+test.py:31: warning: Unsupported default attribute value
+test.py:37: error: Only class variables defined as ClassVar can be assigned to
+test.py:40: error: Unimplemented del operation
+test.py:66: error: complex literals are unimplemented
+test.py:68: warning: Unsupported default argument value
+test.py:75: warning: Treating generator comprehension as list
+test.py:78: error: **args in dict expressions is unimplemented
+test.py:80: error: async functions are unimplemented
+test.py:81: error: await is unimplemented
+test.py:84: error: yield from is unimplemented
+foo/bar.py:1: error: Relative imports are unimplemented
+Aborting due to 22 errors
+

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -102,50 +102,51 @@ from typing import List, Any
 from typing_extensions import Final
 from mypy_extensions import trait
 
-def args(*x: int) -> int:
+def args(*x: int) -> int:  # E: Accepting *args or **kwargs is unimplemented
     return sum(x)
 
+def kwargs(**x: int) -> None:  # E: Accepting *args or **kwargs is unimplemented
+    pass
+
 def foo(x: List[int]) -> List[int]:
-    return [1, 2, *x]
+    return [1, 2, *x]  # E: Star expressions (in non call contexts) are unimplemented
 
 def busted(b: bool) -> None:
-    for i in range(1, 10, 0):
+    for i in range(1, 10, 0):  # E: range() step can't be zero
         try:
             if i == 5:
-                break
+                break  # E: break inside try/finally block is unimplemented
             elif i == 4:
-                continue
+                continue  # E: continue inside try/finally block is unimplemented
         finally:
             print('oops')
-    reveal_type(b)  # type: ignore
-    reveal_locals()  # type: ignore
 
 print(foo([1,2,3]))
 
 x = [1,2]
 
 class Foo:
-    a, b = (10, 20)
-    x[0] = 10
+    a, b = (10, 20)  # E: Only assignment to variables is supported in class bodies
+    x[0] = 10  # E: Only assignment to variables is supported in class bodies
     lol = 20
-    l = [10]
-    c = d = 50
+    l = [10]  # W: Unsupported default attribute value
+    c = d = 50  # E: Multiple assignment in class bodies not supported
 
-    if 1+1 == 2:
+    if 1+1 == 2:  # E: Unsupported statement in class body
         x = 10
 
-Foo.lol = 50
+Foo.lol = 50  # E: Only class variables defined as ClassVar can be assigned to
 
 print(x)
-del x
+del x  # E: Unimplemented del operation
 
 def decorator(x: Any) -> Any:
     return x
 
-class NeverMetaclass(type):
+class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented
     pass
 
-@decorator
+@decorator  # E: Metaclasses are not supported  # E: Class decorators are not supported
 class Wrong(metaclass=NeverMetaclass):
     pass
 
@@ -163,58 +164,27 @@ class Concrete2:
 class Trait2(Concrete2):
     pass
 
-cmplx = 2+5j
+cmplx = 2+5j  # E: complex literals are unimplemented
 
-def warning(x: List[int] = []) -> None:
+def warning(x: List[int] = []) -> None:  # W: Unsupported default argument value
     pass
 
-# check that concrete bases need to come first and that non-trait MRO must be linear
-class Nope(Trait1, Concrete2):
+class Nope(Trait1, Concrete2):  # E: Non-trait bases must appear first in parent list  # E: Non-trait MRO must be linear
     pass
 
-iterator_warning = (i+1 for i in range(10))
+iterator_warning = (i+1 for i in range(10))  # W: Treating generator comprehension as list
 
 d1 = {1: 2}
-d2 = {2: 3, **d1}
+d2 = {2: 3, **d1}  # E: **args in dict expressions is unimplemented
 
-async def aio(x: Any) -> Any:
-    await x
+async def aio(x: Any) -> Any:  # E: async functions are unimplemented
+    await x  # E: await is unimplemented
 
 def yieldfrom(x: Any) -> Any:
-    yield from x
+    yield from x  # E: yield from is unimplemented
 
 [file foo/__init__.py]
 x = 20
 
 [file foo/bar.py]
-from . import x
-
-
-[out]
-test.py:45: error: Inheriting from most builtin types is unimplemented
-test.py:48: error: Metaclasses are not supported
-test.py:48: error: Class decorators are not supported
-test.py:72: error: Non-trait bases appear first in parent list
-test.py:72: error: Non-trait MRO must be linear
-test.py:5: error: Accepting *args or **kwargs is unimplemented
-test.py:9: error: Star expressions (in non call contexts) are unimplemented
-test.py:12: error: range() step can't be zero
-test.py:15: error: break inside try/finally block is unimplemented
-test.py:17: error: continue inside try/finally block is unimplemented
-test.py:28: error: Only assignment to variables is supported in class bodies
-test.py:29: error: Only assignment to variables is supported in class bodies
-test.py:32: error: Multiple assignment in class bodies not supported
-test.py:34: error: Unsupported statement in class body
-test.py:31: warning: Unsupported default attribute value
-test.py:37: error: Only class variables defined as ClassVar can be assigned to
-test.py:40: error: Unimplemented del operation
-test.py:66: error: complex literals are unimplemented
-test.py:68: warning: Unsupported default argument value
-test.py:75: warning: Treating generator comprehension as list
-test.py:78: error: **args in dict expressions is unimplemented
-test.py:80: error: async functions are unimplemented
-test.py:81: error: await is unimplemented
-test.py:84: error: yield from is unimplemented
-foo/bar.py:1: error: Relative imports are unimplemented
-Aborting due to 22 errors
-
+from . import x  # E: Relative imports are unimplemented

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -3325,3 +3325,24 @@ L2:
     return r2
 L3:
     unreachable
+
+[case testRevealType]
+def f(x: int) -> None:
+    reveal_type(x)  # type: ignore
+[out]
+def f(x):
+    x :: int
+    r0 :: object
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: int
+    r6 :: None
+L0:
+    r0 = builtins.module :: static
+    r1 = unicode_1 :: static  ('reveal_type')
+    r2 = getattr r0, r1
+    r3 = box(int, x)
+    r4 = py_call(r2, r3)
+    r5 = unbox(int, r4)
+    r6 = None
+    return r6


### PR DESCRIPTION
Add an error reporting system and report errors instead of crashing
on unimplemented or unsupported features.

Also adds checks for some things we would silently miscompile before.

Error reporting is non-blocking. If we hit an error while compiling an
expression, we create a dummy temporary of the right type so code that
uses it can still be compiled. (Of course, the only reason to keep
compiling it is to see if it produces more errors.)