### PR TITLE
Don't trip an assert on abstract classes/traits without implementations

### DIFF
--- a/test-data/run-traits.test
+++ b/test-data/run-traits.test
@@ -29,6 +29,12 @@ def use_c(c: C) -> int:
 
 use_t(C())
 
+# This trait is dead code but there's no reason it shouldn't compile
+@trait
+class ChildlessTrait:
+    def __init__(self) -> None:
+        pass
+
 [file driver.py]
 from native import A, T, C, use_c, use_t
 c = C()


### PR DESCRIPTION
They shouldn't be able to be created but that's no reason to crash on
seeing them.