### PR TITLE
Disable LTCG on windows in multi-file mode

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -402,7 +402,9 @@ def mypycify(paths: List[str],
             '/wd4146',  # negating unsigned int
         ]
         if multi_file:
-            # Disable whole program optimization in multi-file mode
+            # Disable whole program optimization in multi-file mode so
+            # that we actually get the compilation speed and memory
+            # use wins that multi-file mode is intended for.
             cflags += [
                 '/GL-',
                 '/wd9025',  # warning about overriding /GL

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -401,6 +401,12 @@ def mypycify(paths: List[str],
             '/wd4101',  # unreferenced local variable
             '/wd4146',  # negating unsigned int
         ]
+        if multi_file:
+            # Disable whole program optimization in multi-file mode
+            cflags += [
+                '/GL-',
+                '/wd9025',  # warning about overriding /GL
+            ]
 
     # Copy the runtime library in
     rt_file = os.path.join(build_dir, 'CPy.c')


### PR DESCRIPTION
This makes compilation faster and memory-intensive.
In some unscientific measurements, it seemed to slow down
a compiled mypy self check by less than 1%