### PR TITLE
Don't assert when we are confused about arguments.

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -4409,7 +4409,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                                   sig_arg_kinds,
                                                   sig_arg_names,
                                                   lambda n: AnyType(TypeOfAny.special_form))
-        assert all(len(lst) <= 1 for lst in formal_to_actual)
         return [None if len(lst) == 0 else args[lst[0]] for lst in formal_to_actual]
 
     def get_func_target(self, fdef: FuncDef) -> AssignmentTarget:


### PR DESCRIPTION
We'll report an error at the *args declaration site so don't cause
trouble at call sites.