### PR TITLE
Compare/hash unions based on the set of the types

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -249,6 +249,7 @@ class RUnion(RType):
     def __init__(self, items: List[RType]) -> None:
         self.name = 'union'
         self.items = items
+        self.items_set = frozenset(items)
         self._ctype = 'PyObject *'
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
@@ -260,11 +261,12 @@ class RUnion(RType):
     def __str__(self) -> str:
         return 'union[%s]' % ', '.join(str(item) for item in self.items)
 
+    # We compare based on the set because order in a union doesn't matter
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, RUnion) and other.items == self.items
+        return isinstance(other, RUnion) and self.items_set == other.items_set
 
     def __hash__(self) -> int:
-        return hash(('union', tuple(hash(item) for item in self.items)))
+        return hash(('union', self.items_set))
 
 
 def optional_value_type(rtype: RType) -> Optional[RType]:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3775,3 +3775,22 @@ class E:
 
 [file driver.py]
 # really I only care it builds
+
+[case testTupleUnionFail]
+# Test that order is irrelevant to unions
+
+from typing import Optional, Tuple
+
+class A:
+    pass
+
+def lol() -> A:
+    return A()
+
+def foo(x: bool, y: bool) -> Tuple[Optional[A], bool]:
+    z = lol()
+
+    return None if y else z, x
+
+[file driver.py]
+# really I only care it builds


### PR DESCRIPTION
Do this because order of elements in a union doesn't matter and them
being different was causing us to produce different tuple structs
depending on the order, which caused a mypy_mypyc build breakage.