### PR TITLE
Fix trait compilation bug that is dependent on file order

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -239,8 +239,10 @@ def compute_vtable(cls: ClassIR) -> None:
     """Compute the vtable structure for a class."""
     if cls.vtable is not None: return
 
-    # Merge attributes from traits into the class
     for t in cls.mro[1:]:
+        # Make sure all ancestors are processed first
+        compute_vtable(t)
+        # Merge attributes from traits into the class
         if not t.is_trait:
             continue
         for name, typ in t.attributes.items():
@@ -249,7 +251,6 @@ def compute_vtable(cls: ClassIR) -> None:
 
     cls.vtable = {}
     if cls.base:
-        compute_vtable(cls.base)
         assert cls.base.vtable is not None
         cls.vtable.update(cls.base.vtable)
         cls.vtable_entries = specialize_parent_vtable(cls, cls.base)

--- a/test-data/run-traits.test
+++ b/test-data/run-traits.test
@@ -198,3 +198,28 @@ def lol(x: S1) -> None:
 [file driver.py]
 import native
 native.lol(native.D())
+
+[case testTraitOrdering]
+import other_b
+# Regression test for a bug where inheriting from a class that
+# inherited from a trait that got processed later on the command line
+# filed to compile.
+[file other_b.py]
+from other_c import Plugin
+
+class Whatever(Plugin):
+    pass
+
+[file other_c.py]
+from mypy_extensions import trait
+
+@trait
+class Base:
+    x = None  # type: int
+
+class Plugin(Base):
+    def __init__(self) -> None:
+        self.x = 10
+
+[file driver.py]
+from native import *


### PR DESCRIPTION
compute_vtable was computing vtables of parents too late, which caused
attributes copied in from a trait to be able to appear twice if the
base class came from a module that is processed after the child.

Call compute_vtable on ancestors more aggressively.