### PR TITLE
Special case some functions to prevent generator warnings

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2437,6 +2437,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # Gen the argument values
         arg_values = [self.accept(arg) for arg in expr.args]
 
+        return self.call_refexpr_with_args(expr, callee, arg_values)
+
+    def call_refexpr_with_args(
+            self, expr: CallExpr, callee: RefExpr, arg_values: List[Value]) -> Value:
+
         # Handle data-driven special-cased primitive call ops.
         if callee.fullname is not None and expr.arg_kinds == [ARG_POS] * len(arg_values):
             ops = func_ops.get(callee.fullname, [])
@@ -3252,17 +3257,19 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.add(Unreachable())
         self.activate_block(ok_block)
 
-    def visit_list_comprehension(self, o: ListComprehension) -> Value:
-        gen = o.generator
-        list_ops = self.primitive_op(new_list_op, [], o.line)
+    def translate_list_comprehension(self, gen: GeneratorExpr) -> Value:
+        list_ops = self.primitive_op(new_list_op, [], gen.line)
         loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
 
         def gen_inner_stmts() -> None:
             e = self.accept(gen.left_expr)
-            self.primitive_op(list_append_op, [list_ops, e], o.line)
+            self.primitive_op(list_append_op, [list_ops, e], gen.line)
 
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
+        self.comprehension_helper(loop_params, gen_inner_stmts, gen.line)
         return list_ops
+
+    def visit_list_comprehension(self, o: ListComprehension) -> Value:
+        return self.translate_list_comprehension(o.generator)
 
     def visit_set_comprehension(self, o: SetComprehension) -> Value:
         gen = o.generator
@@ -3290,17 +3297,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def visit_generator_expr(self, o: GeneratorExpr) -> Value:
         self.warning('Treating generator comprehension as list', o.line)
-
-        gen = o
-        list_ops = self.primitive_op(new_list_op, [], o.line)
-        loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
-
-        def gen_inner_stmts() -> None:
-            e = self.accept(gen.left_expr)
-            self.primitive_op(list_append_op, [list_ops, e], o.line)
-
-        self.comprehension_helper(loop_params, gen_inner_stmts, o.line)
-        return self.primitive_op(iter_op, [list_ops], o.line)
+        return self.primitive_op(iter_op, [self.translate_list_comprehension(o)], o.line)
 
     def comprehension_helper(self,
                              loop_params: List[Tuple[Lvalue, Expression, List[Expression]]],
@@ -3548,6 +3545,37 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 return self.add(LoadInt(len(expr_rtype.types)))
         return None
 
+    # Special cases for things that consume iterators where we know we
+    # can safely compile a generator into a list.
+    @specialize_function('builtins.tuple')
+    @specialize_function('builtins.set')
+    @specialize_function('builtins.dict')
+    @specialize_function('builtins.sum')
+    @specialize_function('builtins.min')
+    @specialize_function('builtins.max')
+    @specialize_function('builtins.sorted')
+    @specialize_function('collections.OrderedDict')
+    @specialize_function('join', str_rprimitive)
+    @specialize_function('extend', list_rprimitive)
+    @specialize_function('update', dict_rprimitive)
+    @specialize_function('update', set_rprimitive)
+    def translate_safe_generator_call(self, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
+        if (len(expr.args) > 0
+                and expr.arg_kinds[0] == ARG_POS
+                and isinstance(expr.args[0], GeneratorExpr)):
+            if isinstance(callee, MemberExpr):
+                return self.gen_method_call(
+                    self.accept(callee.expr), callee.name,
+                    ([self.translate_list_comprehension(expr.args[0])]
+                        + [self.accept(arg) for arg in expr.args[1:]]),
+                    self.node_type(expr), expr.line, expr.arg_kinds, expr.arg_names)
+            else:
+                return self.call_refexpr_with_args(
+                    expr, callee,
+                    ([self.translate_list_comprehension(expr.args[0])]
+                        + [self.accept(arg) for arg in expr.args[1:]]))
+        return None
+
     @specialize_function('builtins.any')
     def translate_any_call(self, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
         if (len(expr.args) == 1
@@ -3588,6 +3616,42 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.comprehension_helper(loop_params, gen_inner_stmts, gen.line)
         self.goto_and_activate(exit_block)
 
+        return retval
+
+    # Special case for calling next() on a generator expression, an
+    # idiom that shows up some in mypy.
+    @specialize_function('builtins.next')
+    def translate_next_call(self, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
+        if not (expr.arg_kinds in ([ARG_POS], [ARG_POS, ARG_POS])
+                and isinstance(expr.args[0], GeneratorExpr)):
+            return None
+
+        gen = expr.args[0]
+
+        retval = self.alloc_temp(self.node_type(expr))
+        default_val = None
+        if len(expr.args) > 1:
+            default_val = self.accept(expr.args[1])
+
+        exit_block = BasicBlock()
+
+        def gen_inner_stmts() -> None:
+            # If we ever hit something inside, we're done! Congrats!
+            self.assign(retval, self.accept(gen.left_expr), gen.left_expr.line)
+            self.goto(exit_block)
+
+        loop_params = list(zip(gen.indices, gen.sequences, gen.condlists))
+        self.comprehension_helper(loop_params, gen_inner_stmts, gen.line)
+
+        # Now we need the case for when nothing got hit:
+        if default_val:
+            self.assign(retval, default_val, gen.left_expr.line)
+            self.goto(exit_block)
+        else:
+            self.add(RaiseStandardError(RaiseStandardError.STOP_ITERATION, None, expr.line))
+            self.add(Unreachable())
+
+        self.activate_block(exit_block)
         return retval
 
     @specialize_function('builtins.isinstance')

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -169,6 +169,11 @@ class Nope(Trait1, Concrete2):  # E: Non-trait bases must appear first in parent
 
 iterator_warning = (i+1 for i in range(10))  # W: Treating generator comprehension as list
 
+# But we don't want warnings for these cases:
+tup = tuple(i+1 for i in range(10))
+a_str = " ".join(str(i) for i in range(10))
+wtvr = next(i for i in range(10) if i == 5)
+
 d1 = {1: 2}
 d2 = {2: 3, **d1}  # E: **args in dict expressions is unimplemented
 

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -178,7 +178,10 @@ def len(o: object) -> int: pass
 def print(*object) -> None: pass
 def range(x: int, y: int = ..., z: int = ...) -> Iterator[int]: pass
 def isinstance(x: object, t: object) -> bool: pass
+@overload
 def next(i: Iterator[T]) -> T: pass
+@overload
+def next(i: Iterator[T], default: T) -> T: pass
 def hash(o: object) -> int: ...
 def globals() -> Dict[str, Any]: ...
 def setattr(object: Any, name: str, value: Any) -> None: ...

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3612,6 +3612,58 @@ assert call_all(mixed_110) == 1
 assert call_any_nested([[1, 1, 1], [1, 1], []]) == 1
 assert call_any_nested([[1, 1, 1], [0, 1], []]) == 0
 
+[case testNextGenerator]
+from typing import Iterable
+
+def f(x: int) -> int:
+    print(x)
+    return x
+
+def call_next_loud(l: Iterable[int], val: int) -> int:
+    return next(i for i in l if f(i) == val)
+
+def call_next_default(l: Iterable[int], val: int) -> int:
+    return next((i*2 for i in l if i == val), -1)
+
+def call_next_default_list(l: Iterable[int], val: int) -> int:
+    return next((i*2 for i in l if i == val), -1)
+[file driver.py]
+from native import call_next_loud, call_next_default, call_next_default_list
+
+assert call_next_default([0, 1, 2], 0) == 0
+assert call_next_default([0, 1, 2], 1) == 2
+assert call_next_default([0, 1, 2], 2) == 4
+assert call_next_default([0, 1, 2], 3) == -1
+assert call_next_default([], 0) == -1
+assert call_next_default_list([0, 1, 2], 0) == 0
+assert call_next_default_list([0, 1, 2], 1) == 2
+assert call_next_default_list([0, 1, 2], 2) == 4
+assert call_next_default_list([0, 1, 2], 3) == -1
+assert call_next_default_list([], 0) == -1
+
+assert call_next_loud([0, 1, 2], 0) == 0
+assert call_next_loud([0, 1, 2], 1) == 1
+assert call_next_loud([0, 1, 2], 2) == 2
+try:
+    call_next_loud([42], 3)
+except StopIteration:
+    print("got here")
+try:
+    call_next_loud([], 3)
+except StopIteration:
+    print("got here")
+
+[out]
+0
+0
+1
+0
+1
+2
+42
+got here
+got here
+
 [case testAssignModule]
 import a
 assert a.x == 20


### PR DESCRIPTION
Two main cases here:
* Functions like tuple/set/sum where we just compile to list and
  suppress the warning, since we know it is sound to do so.  (And, to
  be honest, probably more efficient than a real generator would be!)
* next, which mypy uses a fair amount to pick this first thing
  matching some condition and which is not technically sound to
  convert to a list. We just directly implement code for it.

Closes #540, at least arguably.

(It is pretty unclear that implementing `next` was a good use of my time but now that it is done I think it is worth merging.)