### PR TITLE
Add descriptors for __dict__ and __weakref__ when they exist

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <Python.h>
 #include <frameobject.h>
+#include <structmember.h>
 #include <assert.h>
 #include "pythonsupport.h"
 #include "mypyc_util.h"


### PR DESCRIPTION
Otherwise it will fall back to descriptors for the parents which are wrong.