### PR TITLE
Don't leak the old element when writing to a list

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -673,7 +673,7 @@ static bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
             }
         }
         // PyList_SET_ITEM doesn't decref the old element, so we do
-        Py_XDECREF(PyList_GET_ITEM(list, n));
+        Py_DECREF(PyList_GET_ITEM(list, n));
         // N.B: Steals reference
         PyList_SET_ITEM(list, n, value);
         return true;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -672,6 +672,8 @@ static bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
                 return false;
             }
         }
+        // PyList_SET_ITEM doesn't decref the old element, so we do
+        Py_XDECREF(PyList_GET_ITEM(list, n));
         // N.B: Steals reference
         PyList_SET_ITEM(list, n, value);
         return true;


### PR DESCRIPTION
PyList_SET_ITEM doesn't decref the old element, so we need to

Work towards fixing #555