### PR TITLE
Fix issues with signature changing method overrides

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -29,7 +29,7 @@ def native_setter_name(cl: ClassIR, attribute: str, names: NameGenerator) -> str
 
 
 def native_function_type(fn: FuncIR, emitter: Emitter) -> str:
-    args = ', '.join(emitter.ctype(arg.type) for arg in fn.args)
+    args = ', '.join(emitter.ctype(arg.type) for arg in fn.args) or 'void'
     ret = emitter.ctype(fn.ret_type)
     return '{} (*)({})'.format(ret, args)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -213,7 +213,7 @@ def specialize_parent_vtable(cls: ClassIR, parent: ClassIR) -> VTableEntries:
     for entry in parent.vtable_entries:
         if isinstance(entry, VTableMethod):
             # Find the original method corresponding to this vtable entry.
-            # (This may not be the method in the entry, if it was overloaded.)
+            # (This may not be the method in the entry, if it was overridden.)
             orig_parent_method = entry.cls.get_method(entry.name)
             assert orig_parent_method
             method_cls = cls.get_method_and_class(entry.name)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -212,19 +212,20 @@ def specialize_parent_vtable(cls: ClassIR, parent: ClassIR) -> VTableEntries:
     updated = []
     for entry in parent.vtable_entries:
         if isinstance(entry, VTableMethod):
-            method = entry.method
-            child_method = None
-
-            method_cls = cls.get_method_and_class(method.name)
+            # Find the original method corresponding to this vtable entry.
+            # (This may not be the method in the entry, if it was overloaded.)
+            orig_parent_method = entry.cls.get_method(entry.name)
+            assert orig_parent_method
+            method_cls = cls.get_method_and_class(entry.name)
             if method_cls:
                 child_method, defining_cls = method_cls
                 # TODO: emit a wrapper for __init__ that raises or something
-                if (is_same_method_signature(method.sig, child_method.sig)
-                        or method.name == '__init__'):
-                    entry = VTableMethod(defining_cls, entry.name, child_method)
+                if (is_same_method_signature(orig_parent_method.sig, child_method.sig)
+                        or orig_parent_method.name == '__init__'):
+                    entry = VTableMethod(entry.cls, entry.name, child_method)
                 else:
-                    entry = VTableMethod(defining_cls, entry.name,
-                                         defining_cls.glue_methods[(entry.cls, method.name)])
+                    entry = VTableMethod(entry.cls, entry.name,
+                                         defining_cls.glue_methods[(entry.cls, entry.name)])
         else:
             # If it is an attribute from a trait, we need to find out
             # the real class it got mixed in at and point to that.
@@ -1172,20 +1173,20 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         values.
         """
         self.enter(FuncInfo())
-
-        rt_args = (RuntimeArg(sig.args[0].name, RInstance(cls)),) + sig.args[1:]
-
-        # TODO: could kw only arguments get shuffled?
-        # The environment operates on Vars, so we make some up
-        fake_vars = [(Var(arg.name), arg.type) for arg in rt_args]
-        args_opt = [self.read(self.environment.add_local_reg(var, type, is_arg=True), line)
-                    for var, type in fake_vars]  # type: List[Optional[Value]]
-        args_opt += [None] * (len(target.sig.args) - len(args_opt))
         self.ret_types[-1] = sig.ret_type
 
-        args = self.missing_args_to_error_values(args_opt, target.sig)
-        args = self.coerce_native_call_args(args, target.sig, line)
-        retval = self.add(MethodCall(args[0], target.name, args[1:], line))
+        rt_args = list(sig.args)
+        if target.decl.kind == FUNC_NORMAL:
+            rt_args[0] = RuntimeArg(sig.args[0].name, RInstance(cls))
+
+        # The environment operates on Vars, so we make some up
+        fake_vars = [(Var(arg.name), arg.type) for arg in rt_args]
+        args = [self.read(self.environment.add_local_reg(var, type, is_arg=True), line)
+                for var, type in fake_vars]
+        arg_names = [arg.name for arg in rt_args]
+        arg_kinds = [arg.kind for arg in rt_args]
+
+        retval = self.call(target.decl, args, arg_kinds, arg_names, line)
         retval = self.coerce(retval, sig.ret_type, line)
         self.add(Return(retval))
 
@@ -1193,7 +1194,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return FuncIR(
             FuncDecl(target.name + '__' + base.name + '_glue',
                      cls.name, self.module_name,
-                     FuncSignature(rt_args, ret_type)),
+                     FuncSignature(rt_args, ret_type),
+                     target.decl.kind),
             blocks, env)
 
     def gen_glue_property(self, sig: FuncSignature, target: FuncIR, cls: ClassIR, base: ClassIR,
@@ -2384,7 +2386,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def call(self, decl: FuncDecl, args: Sequence[Value],
              arg_kinds: List[int],
-             arg_names: List[Optional[str]],
+             arg_names: Sequence[Optional[str]],
              line: int) -> Value:
         # Normalize keyword args to positionals.
         arg_values_with_nones = self.keyword_args_to_positional(
@@ -2463,7 +2465,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                             arg_kinds=expr.arg_kinds, arg_names=expr.arg_names)
 
     def missing_args_to_error_values(self,
-                                     args: List[Optional[Value]],
+                                     args: Sequence[Optional[Value]],
                                      sig: FuncSignature) -> List[Value]:
         """Generate LoadErrorValues for missing arguments.
 
@@ -4543,7 +4545,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def keyword_args_to_positional(self,
                                    args: Sequence[Value],
                                    arg_kinds: List[int],
-                                   arg_names: List[Optional[str]],
+                                   arg_names: Sequence[Optional[str]],
                                    sig: FuncSignature) -> List[Optional[Value]]:
         # NOTE: This doesn't support *args or **kwargs.
         sig_arg_kinds = [arg.kind for arg in sig.args]

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -258,7 +258,7 @@ def B.foo__A_glue(self, x):
     r0, r1 :: object
 L0:
     r0 = box(int, x)
-    r1 = self.foo(r0)
+    r1 = B.foo(self, r0)
     return r1
 def C.foo(self, x):
     self :: C
@@ -279,7 +279,7 @@ def C.foo__B_glue(self, x):
     r0 :: int
     r1 :: object
 L0:
-    r0 = self.foo(x)
+    r0 = C.foo(self, x)
     r1 = box(int, r0)
     return r1
 def C.foo__A_glue(self, x):
@@ -290,7 +290,7 @@ def C.foo__A_glue(self, x):
     r2 :: object
 L0:
     r0 = box(int, x)
-    r1 = self.foo(r0)
+    r1 = C.foo(self, r0)
     r2 = box(int, r1)
     return r2
 def use_a(x, y):

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -699,7 +699,7 @@ assert b.z is None
 # N.B: this doesn't match cpython
 assert not hasattr(b, 'bogus')
 
-[case testMethodOverrideDefault]
+[case testMethodOverrideDefault1]
 class A:
     def foo(self, x: int) -> None:
         pass
@@ -721,6 +721,81 @@ b(B())
 1 10
 2 10
 2 3
+
+[case testMethodOverrideDefault2]
+class A:
+    def foo(self, *, x: int = 0) -> None:
+        pass
+    def bar(self, *, x: int = 0, y: int = 0) -> None:
+        pass
+class B(A):
+    def foo(self, *, y: int = 0, x: int = 0) -> None:
+        print(x, y)
+    def bar(self, *, y: int = 0, x: int = 0) -> None:
+        print(x, y)
+
+def a(x: A) -> None:
+    x.foo(x=1)
+    x.bar(x=1, y=2)
+    x.bar(x=2, y=1)
+
+[file driver.py]
+from native import B, a
+a(B())
+[out]
+1 0
+1 2
+2 1
+
+[case testMethodOverrideDefault3]
+class A:
+    @classmethod
+    def foo(cls, *, x: int = 0) -> None:
+        pass
+    @staticmethod
+    def bar(*, x: int = 0) -> None:
+        pass
+    @staticmethod
+    def baz() -> object:
+        pass
+class B(A):
+    @classmethod
+    def foo(cls, *, y: int = 0, x: int = 0) -> None:
+        print(x, y)
+        print(cls.__name__)  # type: ignore
+    @staticmethod
+    def bar(*, y: int = 0, x: int = 0) -> None:
+        print(x, y)
+    @staticmethod
+    def baz() -> int:
+        return 10
+
+# This is just to make sure that this stuff works even when the
+# methods might be overriden.
+class C(B):
+    @classmethod
+    def foo(cls, *, y: int = 0, x: int = 0) -> None:
+        pass
+    @staticmethod
+    def bar(*, y: int = 0, x: int = 0) -> None:
+        pass
+    @staticmethod
+    def baz() -> int:
+        return 10
+
+def a(x: A) -> None:
+    x.foo(x=1)
+    x.bar(x=1)
+    print(x.baz())
+
+[file driver.py]
+from native import B, a
+a(B())
+[out]
+1 0
+B
+1 0
+10
 
 [case testOverride]
 class A:


### PR DESCRIPTION
There are two issues fixed here.
 * Fix reordering/adding keyword only arguments when overriding methods.
 * Fix changing method signatures for classmethods/staticmethods

Both of these are fixed in the same way, which is to change the glue to use
the standard call logic.

This then requires a fix to vtable generation to use the right glue.
Previously, if we had a hierarchy A -> B -> C, all changing the
signature of a method foo, we would generate C glue methods to match
both the A and B methods, but we wouldn't actually use the glue for A
(instead using the glue for B, which would then call C's glue for B).

This bug is actually causing incorrect code generation in the new mypy semantic analyzer! A bunch of boolean arguments get reshuffled and this results in error messages not being disabled in certain places.