### PR TITLE
Emit an error for kwonly args appearing after optional ones

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1315,15 +1315,16 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         if any(kind in (ARG_STAR, ARG_STAR2) for kind in kinds):
             self.error('Accepting *args or **kwargs is unimplemented', fitem.line)
 
-        # Disallow kwonly args appearing after optional ones, since we would miscompile
-        # the C API wrappers.
+        # Disallow required kwonly args appearing after optional ones,
+        # since we would miscompile the C API wrappers.
         seen_optional = False
         for kind in kinds:
             if kind in (ARG_OPT, ARG_NAMED_OPT):
                 seen_optional = True
             if kind == ARG_NAMED and seen_optional:
-                self.error('Keyword-only args that appear after optional args are unimplemented',
-                           fitem.line)
+                self.error(
+                    'Required keyword-only args that appear after optional args are unimplemented',
+                    fitem.line)
                 break
 
         if fitem.is_coroutine:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -37,7 +37,7 @@ from mypy.nodes import (
     NamedTupleExpr, NewTypeExpr, NonlocalDecl, OverloadedFuncDef, PrintStmt, RaiseStmt,
     RevealExpr, SetExpr, SliceExpr, StarExpr, SuperExpr, TryStmt, TypeAliasExpr, TypeApplication,
     TypeVarExpr, TypedDictExpr, UnicodeExpr, WithStmt, YieldFromExpr, YieldExpr, GDEF, ARG_POS,
-    ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, is_class_var
+    ARG_OPT, ARG_NAMED, ARG_STAR, ARG_NAMED_OPT, ARG_STAR2, is_class_var
 )
 import mypy.nodes
 import mypy.errors
@@ -1311,8 +1311,20 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         | c_obj |   --------------------------+
         +-------+
         """
-        if any(kind in (ARG_STAR, ARG_STAR2) for kind in fitem.arg_kinds):
+        kinds = fitem.arg_kinds
+        if any(kind in (ARG_STAR, ARG_STAR2) for kind in kinds):
             self.error('Accepting *args or **kwargs is unimplemented', fitem.line)
+
+        # Disallow kwonly args appearing after optional ones, since we would miscompile
+        # the C API wrappers.
+        seen_optional = False
+        for kind in kinds:
+            if kind in (ARG_OPT, ARG_NAMED_OPT):
+                seen_optional = True
+            if kind == ARG_NAMED and seen_optional:
+                self.error('Keyword-only args that appear after optional args are unimplemented',
+                           fitem.line)
+                break
 
         if fitem.is_coroutine:
             self.error('async functions are unimplemented', fitem.line)

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -180,6 +180,9 @@ d2 = {2: 3, **d1}  # E: **args in dict expressions is unimplemented
 async def aio(x: Any) -> Any:  # E: async functions are unimplemented
     await x  # E: await is unimplemented
 
+def kwonly1(x: int = 0, *, y: int) -> None: pass  # E: Keyword-only args that appear after optional args are unimplemented
+def kwonly2(*, x: int = 0, y: int) -> None: pass  # E: Keyword-only args that appear after optional args are unimplemented
+
 [file foo/__init__.py]
 x = 20
 

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -180,8 +180,8 @@ d2 = {2: 3, **d1}  # E: **args in dict expressions is unimplemented
 async def aio(x: Any) -> Any:  # E: async functions are unimplemented
     await x  # E: await is unimplemented
 
-def kwonly1(x: int = 0, *, y: int) -> None: pass  # E: Keyword-only args that appear after optional args are unimplemented
-def kwonly2(*, x: int = 0, y: int) -> None: pass  # E: Keyword-only args that appear after optional args are unimplemented
+def kwonly1(x: int = 0, *, y: int) -> None: pass  # E: Required keyword-only args that appear after optional args are unimplemented
+def kwonly2(*, x: int = 0, y: int) -> None: pass  # E: Required keyword-only args that appear after optional args are unimplemented
 
 [file foo/__init__.py]
 x = 20


### PR DESCRIPTION
We miscompile this and it is why mypy.main breaks.