### PR TITLE
Don't leak hash values in tp_hash wrappers

### DIFF
--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -138,6 +138,7 @@ def generate_hash_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
         emitter.emit_line('Py_ssize_t val = CPyTagged_AsLongLong(retval);')
     else:
         emitter.emit_line('Py_ssize_t val = PyLong_AsLongLong(retval);')
+    emitter.emit_dec_ref('retval', fn.ret_type)
     emitter.emit_line('if (PyErr_Occurred()) return -1;')
     # We can't return -1 from a hash function..
     emitter.emit_line('if (val == -1) return -2;')


### PR DESCRIPTION
I missed this one last week because the leaked objects didn't show up
in gc.get_objects or its graph, and my testcase was small enough that
I didn't notice RSS creeping up. It shows up super clearly in a debug
build using sys.getobjects().

Fixes #555. (Again.)