### PR TITLE
Optimize equality for native classes (#474)

### DIFF
--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -314,8 +314,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         assert method is not None
 
         # Can we call the method directly, bypassing vtable?
-        is_direct = all(subc.get_method(name) is method
-                for subc in class_ir.subclasses())
+        is_direct = class_ir.is_method_final(name)
 
         # The first argument gets omitted for static methods and
         # turned into the class for class methods

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2922,8 +2922,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 always_truthy = False
                 if isinstance(value_type, RInstance):
                     # check whether X.__bool__ is always just the default (object.__bool__)
-                    if (not value_type.class_ir.has_method('__bool__') and
-                            value_type.class_ir.is_method_final('__bool__')):
+                    if (not value_type.class_ir.has_method('__bool__')
+                            and value_type.class_ir.is_method_final('__bool__')):
                         always_truthy = True
 
                 if not always_truthy:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2024,8 +2024,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         class_ir = ltype.class_ir
         # Check whether any subclasses of the operand redefines __eq__.
-        cmp_varies_at_runtime = not class_ir.is_method_final('__eq__') \
-            or not class_ir.is_method_final('__ne__')
+        cmp_varies_at_runtime = (not class_ir.is_method_final('__eq__')
+            or not class_ir.is_method_final('__ne__'))
 
         if cmp_varies_at_runtime:
             # We might need to call left.__eq__(right) or right.__eq__(left)
@@ -2922,8 +2922,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 always_truthy = False
                 if isinstance(value_type, RInstance):
                     # check whether X.__bool__ is always just the default (object.__bool__)
-                    if not value_type.class_ir.has_method('__bool__') and \
-                            value_type.class_ir.is_method_final('__bool__'):
+                    if (not value_type.class_ir.has_method('__bool__') and
+                            value_type.class_ir.is_method_final('__bool__')):
                         always_truthy = True
 
                 if not always_truthy:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1505,8 +1505,6 @@ class ClassIR:
 
         # Direct subclasses of this class (use subclasses() to also incude non-direct ones)
         self.children = []  # type: List[ClassIR]
-        # Does this class or any subclass have a __bool__method
-        self.has_bool = False
         # If this a subclass of some built-in python class, the name
         # of the object for that class. We currently only support this
         # in a few ad-hoc cases.
@@ -1549,6 +1547,10 @@ class ClassIR:
         except KeyError:
             return False
         return True
+
+    def is_method_final(self, name: str) -> bool:
+        return all(subc.get_method(name) is self.get_method(name)
+            for subc in self.subclasses())
 
     def has_attr(self, name: str) -> bool:
         try:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -3288,8 +3288,6 @@ L0:
     return r1
 
 [case testDirectlyCall__bool__]
-from typing import Optional
-
 class A:
     def __bool__(self) -> bool:
         return True

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -799,6 +799,109 @@ L0:
     r3 = unbox(int, r2)
     return r3
 
+
+[case testNoEqDefined]
+class A:
+    pass
+
+def f(a: A, b: A) -> bool:
+    return a == b
+
+def f2(a: A, b: A) -> bool:
+    return a != b
+
+[out]
+def f(a, b):
+    a, b :: A
+    r0 :: bool
+L0:
+    r0 = a is b
+    return r0
+def f2(a, b):
+    a, b :: A
+    r0 :: bool
+L0:
+    r0 = a is not b
+    return r0
+
+[case testEqDefined]
+class Base:
+    def __eq__(self, other: object) -> bool:
+        return False
+class Derived(Base):
+    def __eq__(self, other: object) -> bool:
+        return True
+
+def f(a: Base, b: Base) -> bool:
+    return a == b
+
+def f2(a: Base, b: Base) -> bool:
+    return a != b
+
+def fOpt(a: Derived, b: Derived) -> bool:
+    return a == b
+
+def fOpt2(a: Derived, b: Derived) -> bool:
+    return a != b
+
+[out]
+def Base.__eq__(self, other):
+    self :: Base
+    other :: object
+    r0 :: bool
+    r1 :: object
+L0:
+    r0 = False
+    r1 = box(bool, r0)
+    return r1
+def Base.__ne__(self, rhs):
+    self :: Base
+    rhs, r0 :: object
+    r1 :: bool
+L0:
+    r0 = self.__eq__(rhs)
+    r1 = not r0
+    return r1
+def Derived.__eq__(self, other):
+    self :: Derived
+    other :: object
+    r0 :: bool
+    r1 :: object
+L0:
+    r0 = True
+    r1 = box(bool, r0)
+    return r1
+def f(a, b):
+    a, b :: Base
+    r0 :: object
+    r1 :: bool
+L0:
+    r0 = a == b
+    r1 = unbox(bool, r0)
+    return r1
+def f2(a, b):
+    a, b :: Base
+    r0 :: object
+    r1 :: bool
+L0:
+    r0 = a != b
+    r1 = unbox(bool, r0)
+    return r1
+def fOpt(a, b):
+    a, b :: Derived
+    r0 :: object
+    r1 :: bool
+L0:
+    r0 = a.__eq__(b)
+    r1 = unbox(bool, r0)
+    return r1
+def fOpt2(a, b):
+    a, b :: Derived
+    r0 :: bool
+L0:
+    r0 = a.__ne__(b)
+    return r0
+
 [case testDefaultVars]
 from typing import ClassVar, Optional
 class A:

--- a/test-data/genops-optional.test
+++ b/test-data/genops-optional.test
@@ -26,6 +26,61 @@ L2:
     r4 = 2
     return r4
 
+[case testIsNotNone]
+from typing import Optional
+
+class A: pass
+
+def f(x: Optional[A]) -> int:
+    if x is not None:
+        return 1
+    return 2
+[out]
+def f(x):
+    x :: union[A, None]
+    r0 :: None
+    r1 :: object
+    r2, r3 :: bool
+    r4, r5 :: short_int
+L0:
+    r0 = None
+    r1 = box(None, r0)
+    r2 = x is r1
+    r3 = !r2
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    r4 = 1
+    return r4
+L2:
+    r5 = 2
+    return r5
+
+[case testIsTruthy]
+from typing import Optional
+
+class A: pass
+
+def f(x: Optional[A]) -> int:
+    if x:
+        return 1
+    return 2
+[out]
+def f(x):
+    x :: union[A, None]
+    r0 :: object
+    r1 :: bool
+    r2, r3 :: short_int
+L0:
+    r0 = builtins.None :: object
+    r1 = x is not r0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = 1
+    return r2
+L2:
+    r3 = 2
+    return r3
+
 [case testIsTruthyOverride]
 from typing import Optional
 
@@ -66,35 +121,6 @@ L2:
     r4 = 1
     return r4
 L3:
-    r5 = 2
-    return r5
-
-[case testIsNotNone]
-from typing import Optional
-
-class A: pass
-
-def f(x: Optional[A]) -> int:
-    if x is not None:
-        return 1
-    return 2
-[out]
-def f(x):
-    x :: union[A, None]
-    r0 :: None
-    r1 :: object
-    r2, r3 :: bool
-    r4, r5 :: short_int
-L0:
-    r0 = None
-    r1 = box(None, r0)
-    r2 = x is r1
-    r3 = !r2
-    if r3 goto L1 else goto L2 :: bool
-L1:
-    r4 = 1
-    return r4
-L2:
     r5 = 2
     return r5
 


### PR DESCRIPTION
This does what the original issue #474 requested but there is one issue:

With this example:

```python
from typing import Any
class Val:
    def __init__(self, val:int):
        self.val = val
    def __eq__(self, other:Any) -> bool:
        if not isinstance(other, Val):
            return NotImplemented
        return self.val == other.val

def eqqqq(a:'Val', b:'Val') -> bool:
    return a==b
def neqqqq(a:'Val', b:'Val') -> bool:
    return a!=b

```

We get good code:

```c
char CPyDef_eqqqq(PyObject *cpy_r_a, PyObject *cpy_r_b) {
    PyObject *cpy_r_r0;
    char cpy_r_r1;
    char cpy_r_r2;
CPyL0: ;
    cpy_r_r0 = CPyDef___eq___Val(cpy_r_a, cpy_r_b);

char CPyDef_neqqqq(PyObject *cpy_r_a, PyObject *cpy_r_b) {
    char cpy_r_r0;
    char cpy_r_r1;
CPyL0: ;
    cpy_r_r0 = CPyDef___ne___Val(cpy_r_a, cpy_r_b);
```

Whereas with this example:

```python
from typing import Any

def eqqqq(a:'Val', b:'Val') -> bool:
    return a==b
def neqqqq(a:'Val', b:'Val') -> bool:
    return a!=b

class Val:
    def __init__(self, val:int):
        self.val = val
    def __eq__(self, other:Any) -> bool:
        if not isinstance(other, Val):
            return NotImplemented
        return self.val == other.val
```

We get suboptimal code for neqqqq:
```c
char CPyDef_eqqqq(PyObject *cpy_r_a, PyObject *cpy_r_b) {
    PyObject *cpy_r_r0;
    char cpy_r_r1;
    char cpy_r_r2;
CPyL0: ;
    cpy_r_r0 = CPyDef___eq___Val(cpy_r_a, cpy_r_b);

char CPyDef_neqqqq(PyObject *cpy_r_a, PyObject *cpy_r_b) {
    PyObject *cpy_r_r0;
    PyObject *cpy_r_r1;
    char cpy_r_r2;
    char cpy_r_r3;
CPyL0: ;
    cpy_r_r0 = CPyStatic_unicode_3; /* '__ne__' */
    cpy_r_r1 = PyObject_CallMethodObjArgs(cpy_r_a, cpy_r_r0, cpy_r_b, NULL);
```