### PR TITLE
Support compiling on 32-bit platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,21 @@ MacOS Requirements
 
 * Xcode command line tools
 
-* Python 3.6 (64-bit) from python.org (other versions likely *won't*
-  work right now)
+* Python 3.5+ from python.org (other versions are untested)
 
 Linux Requirements
 ------------------
 
 * A recent enough C/C++ build environment
 
-* Python 3.5+ (64-bit)
+* Python 3.5+
 
 Windows Requirements
 --------------------
 
 * Windows has been tested with Windows 10 and MSVC 2017.
 
-* Python 3.5+ (64-bit)
+* Python 3.5+
 
 Quick Start for Contributors
 ----------------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ cache:
 
 environment:
   matrix:
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -13,7 +13,9 @@ LAMBDA_NAME = '__mypyc_lambda__'
 SELF_NAME = '__mypyc_self__'
 INT_PREFIX = '__tmp_literal_int_'
 
-MAX_SHORT_INT = (1 << 62) - 1
+# Max short int we accept as a literal is based on 32-bit platforms,
+# so that we can just always emit the same code.
+MAX_LITERAL_SHORT_INT = (1 << 30) - 1
 
 TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level
 

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -135,9 +135,9 @@ def generate_hash_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
                                                       fn.cname(emitter.names)))
     emitter.emit_error_check('retval', fn.ret_type, 'return -1;')
     if is_int_rprimitive(fn.ret_type):
-        emitter.emit_line('Py_ssize_t val = CPyTagged_AsLongLong(retval);')
+        emitter.emit_line('Py_ssize_t val = CPyTagged_AsSsize_t(retval);')
     else:
-        emitter.emit_line('Py_ssize_t val = PyLong_AsLongLong(retval);')
+        emitter.emit_line('Py_ssize_t val = PyLong_AsSsize_t(retval);')
     emitter.emit_dec_ref('retval', fn.ret_type)
     emitter.emit_line('if (PyErr_Occurred()) return -1;')
     # We can't return -1 from a hash function..

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -52,7 +52,7 @@ from mypy.checkexpr import map_actuals_to_formals
 
 from mypyc.common import (
     ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, TEMP_ATTR_NAME, LAMBDA_NAME,
-    MAX_SHORT_INT, TOP_LEVEL_NAME, SELF_NAME, decorator_helper_name,
+    MAX_LITERAL_SHORT_INT, TOP_LEVEL_NAME, SELF_NAME, decorator_helper_name,
     FAST_ISINSTANCE_MAX_SUBCLASSES
 )
 from mypyc.prebuildvisitor import PreBuildVisitor
@@ -1552,7 +1552,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         elif isinstance(val, int):
             # TODO: take care of negative integer initializers
             # (probably easier to fix this in mypy itself).
-            if val > MAX_SHORT_INT:
+            if val > MAX_LITERAL_SHORT_INT:
                 return self.load_static_int(val)
             return self.add(LoadInt(val))
         elif isinstance(val, float):
@@ -2072,7 +2072,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             base, '__getitem__', [index_reg], self.node_type(expr), expr.line)
 
     def visit_int_expr(self, expr: IntExpr) -> Value:
-        if expr.value > MAX_SHORT_INT:
+        if expr.value > MAX_LITERAL_SHORT_INT:
             return self.load_static_int(expr.value)
         return self.add(LoadInt(expr.value))
 

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -21,9 +21,6 @@
 #define CPy_dllexport
 #endif
 
-#define CPY_TAGGED_MAX ((1LL << 62) - 1)
-#define CPY_TAGGED_MIN (-(1LL << 62))
-#define CPY_TAGGED_ABS_MIN (0-(unsigned long long)CPY_TAGGED_MIN)
 
 // INCREF and DECREF that assert the pointer is not NULL.
 // asserts are disabled in release builds so there shouldn't be a perf hit.
@@ -33,8 +30,14 @@
 // Here just for consistency
 #define CPy_XDECREF(p) Py_XDECREF(p)
 
-typedef unsigned long long CPyTagged;
-typedef long long CPySignedInt;
+typedef size_t CPyTagged;
+
+#define CPY_INT_BITS (CHAR_BIT * sizeof(CPyTagged))
+
+#define CPY_TAGGED_MAX (((Py_ssize_t)1 << (CPY_INT_BITS - 2)) - 1)
+#define CPY_TAGGED_MIN (-((Py_ssize_t)1 << (CPY_INT_BITS - 2)))
+#define CPY_TAGGED_ABS_MIN (0-(size_t)CPY_TAGGED_MIN)
+
 typedef PyObject CPyModule;
 
 #define CPY_INT_TAG 1
@@ -45,7 +48,7 @@ static inline CPyTagged CPyTagged_ShortFromInt(int x) {
     return x << 1;
 }
 
-static inline CPyTagged CPyTagged_ShortFromLongLong(long long x) {
+static inline CPyTagged CPyTagged_ShortFromSsize_t(Py_ssize_t x) {
     return x << 1;
 }
 

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -150,14 +150,14 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
  * overhead allows the out-parameter overflow flag to be collapsed into
  * control flow.
  * Additionally, we check against the possible range of CPyTagged, not of
- * long long. */
-static inline long long
-CPyLong_AsLongLongAndOverflow(PyObject *vv, int *overflow)
+ * Py_ssize_t. */
+static inline Py_ssize_t
+CPyLong_AsSsize_tAndOverflow(PyObject *vv, int *overflow)
 {
     /* This version by Tim Peters */
     PyLongObject *v = (PyLongObject *)vv;
-    unsigned long long x, prev;
-    long long res;
+    size_t x, prev;
+    Py_ssize_t res;
     Py_ssize_t i;
     int sign;
 
@@ -190,8 +190,8 @@ CPyLong_AsLongLongAndOverflow(PyObject *vv, int *overflow)
         /* Haven't lost any bits, but casting to long requires extra
          * care (see comment above).
          */
-        if (x <= (unsigned long long)CPY_TAGGED_MAX) {
-            res = (long long)x * sign;
+        if (x <= (size_t)CPY_TAGGED_MAX) {
+            res = (Py_ssize_t)x * sign;
         }
         else if (sign < 0 && x == CPY_TAGGED_ABS_MIN) {
             res = CPY_TAGGED_MIN;
@@ -301,7 +301,7 @@ list_count(PyListObject *self, PyObject *value)
         else if (cmp < 0)
             return CPY_INT_TAG;
     }
-    return CPyTagged_ShortFromLongLong(count);
+    return CPyTagged_ShortFromSsize_t(count);
 }
 
 #ifdef __cplusplus

--- a/mypyc/lib-rt/test_capi.cc
+++ b/mypyc/lib-rt/test_capi.cc
@@ -78,10 +78,10 @@ protected:
     PyObject *min_short;
     PyObject *min_pos_long;
     PyObject *max_neg_long;
-    long long c_max_short;
-    long long c_min_short;
-    long long c_min_pos_long;
-    long long c_max_neg_long;
+    Py_ssize_t c_max_short;
+    Py_ssize_t c_min_short;
+    Py_ssize_t c_min_pos_long;
+    Py_ssize_t c_max_neg_long;
 
     virtual void SetUp() {
         if (!is_initialized) {
@@ -122,9 +122,9 @@ TEST_F(CAPITest, test_cint_conversions) {
     EXPECT_EQ(CPyTagged_ShortFromInt(0), 0);
     EXPECT_EQ(CPyTagged_ShortFromInt(3), 6);
     EXPECT_EQ(CPyTagged_ShortFromInt(-5), -10);
-    EXPECT_EQ(CPyTagged_ShortAsLongLong(0), 0);
-    EXPECT_EQ(CPyTagged_ShortAsLongLong(6), 3);
-    EXPECT_EQ(CPyTagged_ShortAsLongLong(-10), -5);
+    EXPECT_EQ(CPyTagged_ShortAsSsize_t(0), 0);
+    EXPECT_EQ(CPyTagged_ShortAsSsize_t(6), 3);
+    EXPECT_EQ(CPyTagged_ShortAsSsize_t(-10), -5);
 }
 
 TEST_F(CAPITest, test_is_long_int) {
@@ -148,8 +148,8 @@ TEST_F(CAPITest, test_obj_to_short_int) {
     EXPECT_EQ(CPyTagged_FromObject(int_from_str("1234")), CPyTagged_ShortFromInt(1234));
     EXPECT_EQ(CPyTagged_FromObject(int_from_str("-1234")), CPyTagged_ShortFromInt(-1234));
 
-    EXPECT_EQ(CPyTagged_FromObject(max_short), CPyTagged_ShortFromLongLong(c_max_short));
-    EXPECT_EQ(CPyTagged_FromObject(min_short), CPyTagged_ShortFromLongLong(c_min_short));
+    EXPECT_EQ(CPyTagged_FromObject(max_short), CPyTagged_ShortFromSsize_t(c_max_short));
+    EXPECT_EQ(CPyTagged_FromObject(min_short), CPyTagged_ShortFromSsize_t(c_min_short));
 }
 
 TEST_F(CAPITest, test_obj_to_long_int) {
@@ -181,9 +181,9 @@ TEST_F(CAPITest, test_short_int_to_obj) {
                             int_from_str("1234")));
     EXPECT_TRUE(is_py_equal(CPyTagged_AsObject(CPyTagged_ShortFromInt(-1234)),
                             int_from_str("-1234")));
-    EXPECT_TRUE(is_py_equal(CPyTagged_AsObject(CPyTagged_ShortFromLongLong(c_max_short)),
+    EXPECT_TRUE(is_py_equal(CPyTagged_AsObject(CPyTagged_ShortFromSsize_t(c_max_short)),
                             max_short));
-    EXPECT_TRUE(is_py_equal(CPyTagged_AsObject(CPyTagged_ShortFromLongLong(c_min_short)),
+    EXPECT_TRUE(is_py_equal(CPyTagged_AsObject(CPyTagged_ShortFromSsize_t(c_min_short)),
                             min_short));
 }
 
@@ -534,11 +534,11 @@ TEST_F(CAPITest, test_tagged_as_long_long) {
     auto s = eval_int("3");
     auto neg = eval_int("-1");
     auto l = eval_int("2**128");
-    EXPECT_TRUE(CPyTagged_AsLongLong(s) == 3);
+    EXPECT_TRUE(CPyTagged_AsSsize_t(s) == 3);
     EXPECT_FALSE(PyErr_Occurred());
-    EXPECT_TRUE(CPyTagged_AsLongLong(neg) == -1);
+    EXPECT_TRUE(CPyTagged_AsSsize_t(neg) == -1);
     EXPECT_FALSE(PyErr_Occurred());
-    EXPECT_TRUE(CPyTagged_AsLongLong(l) == -1);
+    EXPECT_TRUE(CPyTagged_AsSsize_t(l) == -1);
     EXPECT_TRUE(PyErr_Occurred());
 }
 

--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -98,9 +98,9 @@ func_op(
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     temp = emitter.temp_name()
-    emitter.emit_declaration('long long %s;' % temp)
+    emitter.emit_declaration('Py_ssize_t %s;' % temp)
     emitter.emit_line('%s = PyDict_Size(%s);' % (temp, args[0]))
-    emitter.emit_line('%s = CPyTagged_ShortFromLongLong(%s);' % (dest, temp))
+    emitter.emit_line('%s = CPyTagged_ShortFromSsize_t(%s);' % (dest, temp))
 
 
 func_op(name='builtins.len',

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -50,7 +50,7 @@ def int_compare_op(op: str, c_func_name: str) -> None:
               error_kind=ERR_NEVER,
               format_str='{dest} = {args[0]} %s {args[1]} :: short_int' % op,
               emit=simple_emit(
-                  '{dest} = (CPySignedInt){args[0]} %s (CPySignedInt){args[1]};' % op),
+                  '{dest} = (Py_ssize_t){args[0]} %s (Py_ssize_t){args[1]};' % op),
               priority=2)
 
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -120,9 +120,9 @@ method_op(
 
 def emit_multiply_helper(emitter: EmitterInterface, dest: str, lst: str, num: str) -> None:
     temp = emitter.temp_name()
-    emitter.emit_declaration('long long %s;' % temp)
+    emitter.emit_declaration('Py_ssize_t %s;' % temp)
     emitter.emit_lines(
-        "%s = CPyTagged_AsLongLong(%s);" % (temp, num),
+        "%s = CPyTagged_AsSsize_t(%s);" % (temp, num),
         "if (%s == -1 && PyErr_Occurred())" % temp,
         "    CPyError_OutOfMemory();",
         "%s = PySequence_Repeat(%s, %s);" % (dest, lst, temp))
@@ -153,9 +153,9 @@ binary_op(op='*',
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     temp = emitter.temp_name()
-    emitter.emit_declaration('long long %s;' % temp)
+    emitter.emit_declaration('Py_ssize_t %s;' % temp)
     emitter.emit_line('%s = PyList_GET_SIZE(%s);' % (temp, args[0]))
-    emitter.emit_line('%s = CPyTagged_ShortFromLongLong(%s);' % (dest, temp))
+    emitter.emit_line('%s = CPyTagged_ShortFromSsize_t(%s);' % (dest, temp))
 
 
 list_len_op = func_op(name='builtins.len',

--- a/mypyc/ops_set.py
+++ b/mypyc/ops_set.py
@@ -37,9 +37,9 @@ func_op(
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     temp = emitter.temp_name()
-    emitter.emit_declaration('long long %s;' % temp)
+    emitter.emit_declaration('Py_ssize_t %s;' % temp)
     emitter.emit_line('%s = PySet_GET_SIZE(%s);' % (temp, args[0]))
-    emitter.emit_line('%s = CPyTagged_ShortFromLongLong(%s);' % (dest, temp))
+    emitter.emit_line('%s = CPyTagged_ShortFromSsize_t(%s);' % (dest, temp))
 
 
 func_op(

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -25,9 +25,9 @@ tuple_get_item_op = method_op(
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:
     temp = emitter.temp_name()
-    emitter.emit_declaration('long long %s;' % temp)
+    emitter.emit_declaration('Py_ssize_t %s;' % temp)
     emitter.emit_line('%s = PyTuple_GET_SIZE(%s);' % (temp, args[0]))
-    emitter.emit_line('%s = CPyTagged_ShortFromLongLong(%s);' % (dest, temp))
+    emitter.emit_line('%s = CPyTagged_ShortFromSsize_t(%s);' % (dest, temp))
 
 
 tuple_len_op = func_op(

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -94,8 +94,8 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_list_repeat(self) -> None:
         self.assert_emit_binary_op(
             '*', self.ll, self.l, self.n,
-            """long long __tmp1;
-               __tmp1 = CPyTagged_AsLongLong(cpy_r_n);
+            """Py_ssize_t __tmp1;
+               __tmp1 = CPyTagged_AsSsize_t(cpy_r_n);
                if (__tmp1 == -1 && PyErr_Occurred())
                    CPyError_OutOfMemory();
                cpy_r_r0 = PySequence_Repeat(cpy_r_l, __tmp1);
@@ -107,9 +107,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_list_len(self) -> None:
         self.assert_emit(PrimitiveOp([self.l], list_len_op, 55),
-                         """long long __tmp1;
+                         """Py_ssize_t __tmp1;
                             __tmp1 = PyList_GET_SIZE(cpy_r_l);
-                            cpy_r_r0 = CPyTagged_ShortFromLongLong(__tmp1);
+                            cpy_r_r0 = CPyTagged_ShortFromSsize_t(__tmp1);
                          """)
 
     def test_branch(self) -> None:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -967,32 +967,32 @@ def big_int() -> None:
     max_63_bit = 9223372036854775807
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
+    max_31_bit = 1073741823
 [out]
 def big_int():
-    r0 :: short_int
-    a_62_bit :: int
-    r1 :: short_int
-    max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit :: int
-    r6 :: short_int
-    max_32_bit :: int
-    r7 :: None
+    r0, a_62_bit, r1, max_62_bit, r2, b_63_bit, r3, c_63_bit, r4, max_63_bit, r5, d_64_bit, r6, max_32_bit :: int
+    r7 :: short_int
+    max_31_bit :: int
+    r8 :: None
 L0:
-    r0 = 4611686018427387902
+    r0 = int_1 :: static  (4611686018427387902)
     a_62_bit = r0
-    r1 = 4611686018427387903
+    r1 = int_2 :: static  (4611686018427387903)
     max_62_bit = r1
-    r2 = int_1 :: static  (4611686018427387904)
+    r2 = int_3 :: static  (4611686018427387904)
     b_63_bit = r2
-    r3 = int_2 :: static  (9223372036854775806)
+    r3 = int_4 :: static  (9223372036854775806)
     c_63_bit = r3
-    r4 = int_3 :: static  (9223372036854775807)
+    r4 = int_5 :: static  (9223372036854775807)
     max_63_bit = r4
-    r5 = int_4 :: static  (9223372036854775808)
+    r5 = int_6 :: static  (9223372036854775808)
     d_64_bit = r5
-    r6 = 2147483647
+    r6 = int_7 :: static  (2147483647)
     max_32_bit = r6
-    r7 = None
-    return r7
+    r7 = 1073741823
+    max_31_bit = r7
+    r8 = None
+    return r8
 
 [case testCallableTypes]
 from typing import Callable

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1709,6 +1709,7 @@ def big_int() -> None:
     max_63_bit = 9223372036854775807
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
+    max_31_bit = 1073741823
     print(a_62_bit)
     print(max_62_bit)
     print(b_63_bit)
@@ -1716,6 +1717,7 @@ def big_int() -> None:
     print(max_63_bit)
     print(d_64_bit)
     print(max_32_bit)
+    print(max_31_bit)
 [file driver.py]
 from native import big_int
 big_int()
@@ -1727,6 +1729,7 @@ big_int()
 9223372036854775807
 9223372036854775808
 2147483647
+1073741823
 
 [case testForIterable]
 from typing import Iterable, Dict, Any, Tuple


### PR DESCRIPTION
There are basically three parts to this:
 * Only emit int literals that fit in a 32-bit CPyTagged.
   (We could make this conditional, but I like generating the same code
   and it doesn't seem super likely to matter often.)
 * Make all the logic and checks for CPyTagged operations use
   conditionally defined preprocessor constants instead of hardcoded
   constants that depend on it being 64-bit.
 * Don't use long long for everything, since that is bigger than we
   want on 32-bit platforms. Use Py_ssize_t/size_t instead, which
   matches the pointer size. (In practice, if not by the letter of
   the standard, which would have us use intptr_r/uintptr_t.
   We use Py_ssize_t because CPython does.)

This last one results in a lot of churn because I renamed a lot of
functions accordingly.

Turns on a 32-bit Windows build in CI.

Fixes #519.