### PR TITLE
Get running under Python 3.8.0a3+

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -913,6 +913,9 @@ static PyObject *CPyLong_FromFloat(PyObject *o) {
     }
 }
 
+// These functions are basically exactly PyCode_NewEmpty and
+// _PyTraceback_Add which are available in all the versions we support.
+// We're continuing to use them because we'll probably optimize them later.
 static PyCodeObject *CPy_CreateCodeObject(const char *filename, const char *funcname, int line) {
     PyObject *filename_obj = PyUnicode_FromString(filename);
     PyObject *funcname_obj = PyUnicode_FromString(funcname);
@@ -944,20 +947,36 @@ static PyCodeObject *CPy_CreateCodeObject(const char *filename, const char *func
 
 static void CPy_AddTraceback(const char *filename, const char *funcname, int line,
                              PyObject *globals) {
+
+    PyObject *exc, *val, *tb;
+    // We need to save off the exception state because in 3.8,
+    // PyFrame_New fails if there is an error set and it fails to look
+    // up builtins in the globals. (_PyTraceback_Add documents that it
+    // needs to do it because it decodes the filename according to the
+    // FS encoding, which could have a decoder in Python. We don't do
+    // that so *that* doesn't apply to us.)
+    PyErr_Fetch(&exc, &val, &tb);
+
     PyCodeObject *code_obj = CPy_CreateCodeObject(filename, funcname, line);
     if (code_obj == NULL) {
-        return;
+        goto error;
     }
     PyThreadState *thread_state = PyThreadState_GET();
     PyFrameObject *frame_obj = PyFrame_New(thread_state, code_obj, globals, 0);
     if (frame_obj == NULL) {
         Py_DECREF(code_obj);
-        return;
+        goto error;
     }
     frame_obj->f_lineno = line;
+    PyErr_Restore(exc, val, tb);
     PyTraceBack_Here(frame_obj);
     Py_DECREF(code_obj);
     Py_DECREF(frame_obj);
+
+    return;
+
+error:
+    _PyErr_ChainExceptions(exc, val, tb);
 }
 
 // mypyc is not very good at dealing with refcount management of

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -949,6 +949,9 @@ static void CPy_AddTraceback(const char *filename, const char *funcname, int lin
                              PyObject *globals) {
 
     PyObject *exc, *val, *tb;
+    PyThreadState *thread_state = PyThreadState_GET();
+    PyFrameObject *frame_obj;
+
     // We need to save off the exception state because in 3.8,
     // PyFrame_New fails if there is an error set and it fails to look
     // up builtins in the globals. (_PyTraceback_Add documents that it
@@ -956,13 +959,12 @@ static void CPy_AddTraceback(const char *filename, const char *funcname, int lin
     // FS encoding, which could have a decoder in Python. We don't do
     // that so *that* doesn't apply to us.)
     PyErr_Fetch(&exc, &val, &tb);
-
     PyCodeObject *code_obj = CPy_CreateCodeObject(filename, funcname, line);
     if (code_obj == NULL) {
         goto error;
     }
-    PyThreadState *thread_state = PyThreadState_GET();
-    PyFrameObject *frame_obj = PyFrame_New(thread_state, code_obj, globals, 0);
+
+    frame_obj = PyFrame_New(thread_state, code_obj, globals, 0);
     if (frame_obj == NULL) {
         Py_DECREF(code_obj);
         goto error;

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3820,7 +3820,10 @@ import sys
 
 # We lie about the version we are running in tests if it is 3.5, so
 # that hits a crash case.
-if sys.version_info[:2] == (3, 7):
+if sys.version_info[:2] == (3, 8):
+    def version() -> int:
+        return 8
+elif sys.version_info[:2] == (3, 7):
     def version() -> int:
         return 7
 elif sys.version_info[:2] == (3, 6):


### PR DESCRIPTION
Two changes:
 * Fix testCheckVersion to have a case for it
 * Fix a bug in traceback creation

No CI yet because for now I want to only have to fix 3.8 issues on my
schedule instead of whenever Travis might update their 3.8
version. (And also because I remember there being something annoying
about getting 3.7-dev on Travis working.)

Closes #570.