### PR TITLE
Fix multi-file stuff on OS X

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -71,6 +71,7 @@ def setup_mypycify_vars() -> None:
         vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle', '-dynamiclib')
         # Also disable building 32-bit binaries, since we generate too much code
         # for a 32-bit Mach-O object. There has to be a better way to do this.
+        vars['LDSHARED'] = vars['LDSHARED'].replace('-arch i386', '')
         vars['LDFLAGS'] = vars['LDFLAGS'].replace('-arch i386', '')
         vars['CFLAGS'] = vars['CFLAGS'].replace('-arch i386', '')
 

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -21,10 +21,12 @@ from mypyc.sametype import is_same_type
 
 class HeaderDeclaration:
     def __init__(self,
-                 dependencies: Set[str], decl: List[str], defn: Optional[List[str]]) -> None:
+                 dependencies: Set[str], decl: List[str], defn: Optional[List[str]],
+                 needs_extern: bool = False) -> None:
         self.dependencies = dependencies
         self.decl = decl
         self.defn = defn
+        self.needs_extern = needs_extern
 
 
 class EmitterContext:

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -71,8 +71,9 @@ def generate_slots(cl: ClassIR, table: SlotTable, emitter: Emitter) -> Dict[str,
     return fields
 
 
-def generate_class_type_decl(cl: ClassIR, emitter: Emitter) -> None:
-    emitter.emit_line('PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
+def generate_class_type_decl(cl: ClassIR, c_emitter: Emitter, emitter: Emitter) -> None:
+    c_emitter.emit_line('PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
+    emitter.emit_line('extern PyTypeObject *{};'.format(emitter.type_struct_name(cl)))
     emitter.emit_line()
     generate_object_struct(cl, emitter)
     emitter.emit_line()

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -192,12 +192,17 @@ class ModuleGenerator:
         declarations.emit_line()
 
         for declaration in sorted_decls:
-            declarations.emit_lines(*declaration.decl)
+            if declaration.needs_extern:
+                declarations.emit_lines(
+                    'extern {}'.format(declaration.decl[0]), *declaration.decl[1:])
+                emitter.emit_lines(*declaration.decl)
+            else:
+                declarations.emit_lines(*declaration.decl)
 
         for module_name, module in self.modules:
             self.declare_finals(module.final_names, declarations)
             for cl in module.classes:
-                generate_class_type_decl(cl, declarations)
+                generate_class_type_decl(cl, emitter, declarations)
             for fn in module.functions:
                 generate_function_declaration(fn, declarations)
 
@@ -400,6 +405,7 @@ class ModuleGenerator:
                 set(),
                 ['{}{};'.format(type_spaced, name)],
                 defn,
+                needs_extern=True,
             )
 
     def declare_internal_globals(self, module_name: str, emitter: Emitter) -> None:
@@ -427,7 +433,7 @@ class ModuleGenerator:
     def declare_finals(self, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
         for name, typ in final_names:
             static_name = emitter.static_name(name, 'final')
-            emitter.emit_line('{}{};'.format(emitter.ctype_spaced(typ), static_name))
+            emitter.emit_line('extern {}{};'.format(emitter.ctype_spaced(typ), static_name))
 
     def define_finals(self, final_names: Iterable[Tuple[str, RType]], emitter: Emitter) -> None:
         for name, typ in final_names:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -5,7 +5,6 @@ import os.path
 import platform
 import subprocess
 import contextlib
-import unittest
 import sys
 from typing import List, Iterator, Optional
 
@@ -67,10 +66,6 @@ class TestRun(MypycDataSuite):
     multi_file = False
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
-        # FIXME: This is broken and I am investigating -sully
-        if self.multi_file and sys.platform == 'darwin':
-            pytest.skip("multifile tests are broken on macOS")
-
         bench = testcase.config.getoption('--bench', False) and 'Benchmark' in testcase.name
 
         # setup.py wants to be run from the root directory of the package, which we accommodate

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -125,18 +125,24 @@ int CPyGlobalsInit(void)
 CPyModule *CPyStatic_module_internal = NULL;
 CPyModule *CPyStatic_builtins_module_internal = NULL;
 
-== __native.h ==
-#include <Python.h>
-#include <CPy.h>
-
-int CPyGlobalsInit(void);
-
 PyObject *CPyStatic_unicode_0;
 CPyModule *CPyStatic_module_internal;
 CPyModule *CPyStatic_module;
 PyObject *CPyStatic_globals;
 CPyModule *CPyStatic_builtins_module_internal;
 CPyModule *CPyStatic_builtins_module;
+== __native.h ==
+#include <Python.h>
+#include <CPy.h>
+
+int CPyGlobalsInit(void);
+
+extern PyObject *CPyStatic_unicode_0;
+extern CPyModule *CPyStatic_module_internal;
+extern CPyModule *CPyStatic_module;
+extern PyObject *CPyStatic_globals;
+extern CPyModule *CPyStatic_builtins_module_internal;
+extern CPyModule *CPyStatic_builtins_module;
 CPyTagged CPyDef_f(CPyTagged cpy_r_x);
 PyObject *CPyPy_f(PyObject *self, PyObject *args, PyObject *kw);
 char CPyDef___top_level__(void);


### PR DESCRIPTION
Apparently on macOS it doesn't work (anymore?) to have the same symbol
declared in multiple object files without initializing it. So instead
be careful to declare them all as extern and then separately declare
them in the c files.

It worked in CI, too, so I'm pretty confused, but oh well.

Also fix our attempts to keep it from doing 32-bit builds on OS X.