### PR TITLE
Support stripping asserts

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -373,7 +373,8 @@ def mypycify(paths: List[str],
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name, verbose, compiler_options=compiler_options)
+        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name, verbose,
+                                      compiler_options=compiler_options)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -227,7 +227,8 @@ def include_dir() -> str:
 def generate_c(sources: List[BuildSource], options: Options,
                multi_file: bool,
                shared_lib_name: Optional[str],
-               verbose: bool = False) -> Tuple[List[Tuple[str, str]], str]:
+               verbose: bool = False,
+               strip_asserts: bool = False) -> Tuple[List[Tuple[str, str]], str]:
     """Drive the actual core compilation step.
 
     Returns the C source code and (for debugging) the pretty printed IR.
@@ -249,7 +250,7 @@ def generate_c(sources: List[BuildSource], options: Options,
 
     ops = []  # type: List[str]
     ctext = emitmodule.compile_modules_to_c(result, module_names, shared_lib_name, multi_file,
-                                            ops=ops)
+                                            strip_asserts=strip_asserts, ops=ops)
 
     t2 = time.time()
     if verbose:
@@ -326,7 +327,7 @@ def mypycify(paths: List[str],
              multi_file: bool = False,
              skip_cgen: bool = False,
              verbose: bool = False,
-             omit_asserts: bool = False) -> List[MypycifyExtension]:
+             strip_asserts: bool = False) -> List[MypycifyExtension]:
     """Main entry point to building using mypyc.
 
     This produces a list of Extension objects that should be passed as the
@@ -369,7 +370,7 @@ def mypycify(paths: List[str],
     # so that it can do a corner-cutting version without full stubs.
     # TODO: Be able to do this based on file mtimes?
     if not skip_cgen:
-        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name, verbose)
+        cfiles, ops_text = generate_c(sources, options, multi_file, lib_name, verbose, strip_asserts=strip_asserts)
         # TODO: unique names?
         with open(os.path.join(build_dir, 'ops.txt'), 'w') as f:
             f.write(ops_text)

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -325,7 +325,8 @@ def mypycify(paths: List[str],
              opt_level: str = '3',
              multi_file: bool = False,
              skip_cgen: bool = False,
-             verbose: bool = False) -> List[MypycifyExtension]:
+             verbose: bool = False,
+             omit_asserts: bool = False) -> List[MypycifyExtension]:
     """Main entry point to building using mypyc.
 
     This produces a list of Extension objects that should be passed as the

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -46,12 +46,13 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          shared_lib_name: Optional[str],
                          multi_file: bool,
+                         strip_asserts: bool = False,
                          ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
 
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
-    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types)
+    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types, strip_asserts)
     if errors > 0:
         sys.exit(1)
     # Insert uninit checks.

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -18,6 +18,7 @@ from mypyc.emitwrapper import (
     generate_wrapper_function, wrapper_function_header,
 )
 from mypyc.ops import FuncIR, ClassIR, ModuleIR, LiteralsMap, format_func, RType, RTuple
+from mypyc.options import Options as CompilerOptions
 from mypyc.uninit import insert_uninit_checks
 from mypyc.refcount import insert_ref_count_opcodes
 from mypyc.exceptions import insert_exception_handling
@@ -46,13 +47,13 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          shared_lib_name: Optional[str],
                          multi_file: bool,
-                         strip_asserts: bool = False,
+                         compiler_options: CompilerOptions,
                          ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
 
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
-    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types, strip_asserts)
+    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types, compiler_options)
     if errors > 0:
         sys.exit(1)
     # Insert uninit checks.

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -18,7 +18,7 @@ from mypyc.emitwrapper import (
     generate_wrapper_function, wrapper_function_header,
 )
 from mypyc.ops import FuncIR, ClassIR, ModuleIR, LiteralsMap, format_func, RType, RTuple
-from mypyc.options import Options as CompilerOptions
+from mypyc.options import CompilerOptions
 from mypyc.uninit import insert_uninit_checks
 from mypyc.refcount import insert_ref_count_opcodes
 from mypyc.exceptions import insert_exception_handling
@@ -46,7 +46,6 @@ def parse_and_typecheck(sources: List[BuildSource], options: Options,
 
 def compile_modules_to_c(result: BuildResult, module_names: List[str],
                          shared_lib_name: Optional[str],
-                         multi_file: bool,
                          compiler_options: CompilerOptions,
                          ops: Optional[List[str]] = None) -> List[Tuple[str, str]]:
     """Compile Python module(s) to C that can be used from Python C extension modules."""
@@ -78,7 +77,8 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
     # Generate C code.
     source_paths = {module_name: result.files[module_name].path
                     for module_name in module_names}
-    generator = ModuleGenerator(literals, modules, source_paths, shared_lib_name, multi_file)
+    generator = ModuleGenerator(literals, modules, source_paths, shared_lib_name,
+                                compiler_options.multi_file)
     return generator.generate_c_for_modules()
 
 

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -53,7 +53,8 @@ def compile_modules_to_c(result: BuildResult, module_names: List[str],
 
     # Generate basic IR, with missing exception and refcount handling.
     file_nodes = [result.files[name] for name in module_names]
-    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types, compiler_options)
+    literals, modules, errors = genops.build_ir(file_nodes, result.graph, result.types,
+                                                compiler_options)
     if errors > 0:
         sys.exit(1)
     # Insert uninit checks.

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -98,7 +98,7 @@ from mypyc.rt_subtype import is_runtime_subtype
 from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type, is_same_method_signature
 from mypyc.crash import catch_errors
-from mypyc.options import Options
+from mypyc.options import CompilerOptions
 
 GenFunc = Callable[[], None]
 
@@ -129,7 +129,7 @@ class Errors:
 def build_ir(modules: List[MypyFile],
              graph: Graph,
              types: Dict[Expression, Type],
-             options: Options) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]], int]:
+             options: CompilerOptions) -> Tuple[LiteralsMap, List[Tuple[str, ModuleIR]], int]:
     result = []
     mapper = Mapper()
     errors = Errors()
@@ -794,7 +794,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                  mapper: Mapper,
                  modules: List[str],
                  pbv: PreBuildVisitor,
-                 options: Options) -> None:
+                 options: CompilerOptions) -> None:
         self.types = types
         self.graph = graph
         self.environment = Environment()

--- a/mypyc/options.py
+++ b/mypyc/options.py
@@ -1,0 +1,3 @@
+class Options:
+    def __init__(self, strip_asserts: bool = False) -> None:
+        self.strip_asserts = strip_asserts

--- a/mypyc/options.py
+++ b/mypyc/options.py
@@ -1,3 +1,6 @@
-class Options:
-    def __init__(self, strip_asserts: bool = False) -> None:
+class CompilerOptions:
+    def __init__(self, strip_asserts: bool = False, multi_file: bool = False,
+                 verbose: bool = False) -> None:
         self.strip_asserts = strip_asserts
+        self.multi_file = multi_file
+        self.verbose = verbose

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -12,7 +12,7 @@ from mypy.options import Options
 
 from mypyc import genops
 from mypyc import emitmodule
-from mypyc.options import Options as CompilerOptions
+from mypyc.options import CompilerOptions
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
 )
@@ -39,7 +39,7 @@ class TestCompiler(MypycDataSuite):
             options.strict_optional = True
             options.python_version = (3, 6)
             options.export_types = True
-            compiler_options = CompilerOptions()
+            compiler_options = CompilerOptions(multi_file=True)
             source = build.BuildSource('prog.py', 'prog', text)
 
             try:
@@ -48,7 +48,8 @@ class TestCompiler(MypycDataSuite):
                     options=options,
                     alt_lib_path=test_temp_dir)
                 cfiles = emitmodule.compile_modules_to_c(
-                    result, module_names=['prog'], multi_file=True, shared_lib_name=None, compiler_options=compiler_options)
+                    result, module_names=['prog'], shared_lib_name=None,
+                    compiler_options=compiler_options)
                 out = []
                 for cfile, ctext in cfiles:
                     out.append('== {} =='.format(cfile))

--- a/mypyc/test/test_emitmodule.py
+++ b/mypyc/test/test_emitmodule.py
@@ -12,6 +12,7 @@ from mypy.options import Options
 
 from mypyc import genops
 from mypyc import emitmodule
+from mypyc.options import Options as CompilerOptions
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, assert_test_output
 )
@@ -38,6 +39,7 @@ class TestCompiler(MypycDataSuite):
             options.strict_optional = True
             options.python_version = (3, 6)
             options.export_types = True
+            compiler_options = CompilerOptions()
             source = build.BuildSource('prog.py', 'prog', text)
 
             try:
@@ -46,7 +48,7 @@ class TestCompiler(MypycDataSuite):
                     options=options,
                     alt_lib_path=test_temp_dir)
                 cfiles = emitmodule.compile_modules_to_c(
-                    result, module_names=['prog'], multi_file=True, shared_lib_name=None)
+                    result, module_names=['prog'], multi_file=True, shared_lib_name=None, compiler_options=compiler_options)
                 out = []
                 for cfile, ctext in cfiles:
                     out.append('== {} =='.format(cfile))

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -12,6 +12,7 @@ from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, remove_comment_lines
 )
+from mypyc.options import Options
 
 files = [
     'genops-basic.test',
@@ -38,13 +39,13 @@ class TestGenOps(MypycDataSuite):
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         # Kind of hacky. Not sure if we need more structure here.
-        strip_asserts = 'StripAssert' in testcase.name
+        options = Options(strip_asserts='StripAssert' in testcase.name)
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
 
             try:
-                ir = build_ir_for_single_file(testcase.input, strip_asserts)
+                ir = build_ir_for_single_file(testcase.input, options)
             except CompileError as e:
                 actual = e.messages
             else:

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -12,7 +12,7 @@ from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
     assert_test_output, remove_comment_lines
 )
-from mypyc.options import Options
+from mypyc.options import CompilerOptions
 
 files = [
     'genops-basic.test',
@@ -39,7 +39,7 @@ class TestGenOps(MypycDataSuite):
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         # Kind of hacky. Not sure if we need more structure here.
-        options = Options(strip_asserts='StripAssert' in testcase.name)
+        options = CompilerOptions(strip_asserts='StripAssert' in testcase.name)
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)

--- a/mypyc/test/test_genops.py
+++ b/mypyc/test/test_genops.py
@@ -27,6 +27,7 @@ files = [
     'genops-generics.test',
     'genops-try.test',
     'genops-set.test',
+    'genops-strip-asserts.test',
 ]
 
 
@@ -36,12 +37,14 @@ class TestGenOps(MypycDataSuite):
     optional_out = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
+        # Kind of hacky. Not sure if we need more structure here.
+        strip_asserts = 'StripAssert' in testcase.name
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
 
             try:
-                ir = build_ir_for_single_file(testcase.input)
+                ir = build_ir_for_single_file(testcase.input, strip_asserts)
             except CompileError as e:
                 actual = e.messages
             else:

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -17,6 +17,7 @@ from mypy.options import Options
 
 from mypyc import genops
 from mypyc import emitmodule
+from mypyc.options import Options as CompilerOptions
 from mypyc.test.config import prefix
 from mypyc.build import shared_lib_name
 from mypyc.test.testutil import (
@@ -137,7 +138,8 @@ class TestRun(MypycDataSuite):
                     result,
                     module_names=module_names,
                     multi_file=self.multi_file,
-                    shared_lib_name=lib_name)
+                    shared_lib_name=lib_name,
+                    compiler_options=CompilerOptions())
             except CompileError as e:
                 for line in e.messages:
                     print(line)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -17,7 +17,7 @@ from mypy.options import Options
 
 from mypyc import genops
 from mypyc import emitmodule
-from mypyc.options import Options as CompilerOptions
+from mypyc.options import CompilerOptions
 from mypyc.test.config import prefix
 from mypyc.build import shared_lib_name
 from mypyc.test.testutil import (
@@ -137,9 +137,8 @@ class TestRun(MypycDataSuite):
                 cfiles = emitmodule.compile_modules_to_c(
                     result,
                     module_names=module_names,
-                    multi_file=self.multi_file,
                     shared_lib_name=lib_name,
-                    compiler_options=CompilerOptions())
+                    compiler_options=CompilerOptions(multi_file=self.multi_file))
             except CompileError as e:
                 for line in e.messages:
                     print(line)

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -43,7 +43,7 @@ from distutils.core import setup
 from mypyc.build import mypycify, MypycifyBuildExt
 
 setup(name='test_run_output',
-      ext_modules=mypycify({}, skip_cgen=True),
+      ext_modules=mypycify({}, skip_cgen=True, strip_asserts=False),
       cmdclass={{'build_ext': MypycifyBuildExt}},
 )
 """

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -14,6 +14,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc import genops
+from mypyc.options import Options as CompilerOptions
 from mypyc.ops import FuncIR
 from mypyc.test.config import test_data_prefix
 
@@ -76,9 +77,11 @@ def perform_test(func: Callable[[DataDrivenTestCase], None],
         os.remove(builtins)
 
 
-def build_ir_for_single_file(input_lines: List[str], strip_asserts: bool = False) -> List[FuncIR]:
+def build_ir_for_single_file(input_lines: List[str],
+                             compiler_options: Optional[CompilerOptions] = None) -> List[FuncIR]:
     program_text = '\n'.join(input_lines)
 
+    compiler_options = compiler_options or CompilerOptions()
     options = Options()
     options.show_traceback = True
     options.use_builtins_fixtures = True
@@ -95,7 +98,7 @@ def build_ir_for_single_file(input_lines: List[str], strip_asserts: bool = False
                          alt_lib_path=test_temp_dir)
     if result.errors:
         raise CompileError(result.errors)
-    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types, strip_asserts)
+    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types, compiler_options)
     assert errors == 0
 
     module = modules[0][1]

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -76,7 +76,7 @@ def perform_test(func: Callable[[DataDrivenTestCase], None],
         os.remove(builtins)
 
 
-def build_ir_for_single_file(input_lines: List[str]) -> List[FuncIR]:
+def build_ir_for_single_file(input_lines: List[str], strip_asserts: bool = False) -> List[FuncIR]:
     program_text = '\n'.join(input_lines)
 
     options = Options()
@@ -95,7 +95,7 @@ def build_ir_for_single_file(input_lines: List[str]) -> List[FuncIR]:
                          alt_lib_path=test_temp_dir)
     if result.errors:
         raise CompileError(result.errors)
-    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types)
+    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types, strip_asserts)
     assert errors == 0
 
     module = modules[0][1]

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -14,7 +14,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc import genops
-from mypyc.options import Options as CompilerOptions
+from mypyc.options import CompilerOptions
 from mypyc.ops import FuncIR
 from mypyc.test.config import test_data_prefix
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -98,7 +98,8 @@ def build_ir_for_single_file(input_lines: List[str],
                          alt_lib_path=test_temp_dir)
     if result.errors:
         raise CompileError(result.errors)
-    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types, compiler_options)
+    _, modules, errors = genops.build_ir([result.files['__main__']], result.graph, result.types,
+                                         compiler_options)
     assert errors == 0
 
     module = modules[0][1]

--- a/test-data/genops-strip-asserts.test
+++ b/test-data/genops-strip-asserts.test
@@ -1,0 +1,17 @@
+[case testStripAssert1]
+def g():
+  x = 1 + 2
+  assert x < 5
+  return x
+[out]
+def g():
+    r0, r1 :: short_int
+    r2 :: int
+    r3, x :: object
+L0:
+    r0 = 1
+    r1 = 2
+    r2 = r0 + r1 :: int
+    r3 = box(int, r2)
+    x = r3
+    return x

--- a/test-data/genops-strip-asserts.test
+++ b/test-data/genops-strip-asserts.test
@@ -15,3 +15,4 @@ L0:
     r3 = box(int, r2)
     x = r3
     return x
+


### PR DESCRIPTION
Implements the basic work of stripping asserts when compiling. The strategy taken was to thread a strip_asserts flag to genops.visit_assert_stmt, and simply not generate any IR if the flag is set.

Now, this seems like the first flag that mypyc got which influences how we generate code. In the long run, I seriously doubt we want to pass in a laundry list of kwargs, but I went with passing the flag explicitly for now, deferring the decision of how to implement this until later.

My method of testing was, once again, quite hacky, since I'm not too familiar with pytest internals. I welcome suggestions to make that bit better.

I've hooked this up to mypycify and added the strip_asserts=False flag explicitly to test_run for the sake of being explicit.