### PR TITLE
Revert "Always unbox iterable results (#566)"

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1994,14 +1994,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 for_list.init(expr_reg, target_type, reverse=True)
                 return for_list
 
-        type_checker = self.graph[self.module_name].type_checker()
-
         # Default to a generic for loop.
         expr_reg = self.accept(expr)
         for_obj = ForIterable(self, index, body_block, loop_exit, line, nested)
-        _, inferred_item_type = type_checker.analyze_iterable_item_type(expr)
-        item_type = self.type_to_rtype(inferred_item_type)
-        for_obj.init(expr_reg, item_type)
+        for_obj.init(expr_reg)
         return for_obj
 
     def visit_break_stmt(self, node: BreakStmt) -> None:

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -80,7 +80,7 @@ class ForIterable(ForGenerator):
         # Create a new cleanup block for when the loop is finished.
         return True
 
-    def init(self, expr_reg: Value, target_type: RType) -> None:
+    def init(self, expr_reg: Value) -> None:
         # Define targets to contain the expression, along with the iterator that will be used
         # for the for-loop. If we are inside of a generator function, spill these into the
         # environment class.
@@ -88,7 +88,6 @@ class ForIterable(ForGenerator):
         iter_reg = builder.primitive_op(iter_op, [expr_reg], self.line)
         builder.maybe_spill(expr_reg)
         self.iter_target = builder.maybe_spill(iter_reg)
-        self.target_type = target_type
 
     def gen_condition(self) -> None:
         # We call __next__ on the iterator and check to see if the return value
@@ -104,11 +103,7 @@ class ForIterable(ForGenerator):
         # Assign the value obtained from __next__ to the
         # lvalue so that it can be referenced by code in the body of the loop.
         builder = self.builder
-        line = self.line
-        # We unbox here so that iterating with tuple unpacking generates a tuple based
-        # unpack instead of an iterator based one.
-        next_reg = builder.unbox_or_cast(self.next_reg, self.target_type, line)
-        builder.assign(builder.get_assignment_target(self.index), next_reg, line)
+        builder.assign(builder.get_assignment_target(self.index), self.next_reg, self.line)
 
     def gen_step(self) -> None:
         # Nothing to do here, since we get the next item as part of gen_condition().

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -2993,7 +2993,7 @@ def call_any(l):
     l :: object
     r0, r1 :: bool
     r2, r3 :: object
-    r4, i :: int
+    i, r4 :: int
     r5 :: short_int
     r6, r7, r8 :: bool
 L0:
@@ -3025,7 +3025,7 @@ def call_all(l):
     l :: object
     r0, r1 :: bool
     r2, r3 :: object
-    r4, i :: int
+    i, r4 :: int
     r5 :: short_int
     r6, r7, r8, r9 :: bool
 L0:

--- a/test-data/genops-dict.test
+++ b/test-data/genops-dict.test
@@ -156,7 +156,7 @@ def increment(d: Dict[str, int]) -> Dict[str, int]:
 def increment(d):
     d :: dict
     r0, r1 :: object
-    r2, k :: str
+    k, r2 :: str
     r3 :: object
     r4 :: short_int
     r5, r6 :: object

--- a/test-data/genops-generators.test
+++ b/test-data/genops-generators.test
@@ -1809,25 +1809,25 @@ def recursive_outer_gen.__mypyc_generator_helper__(__mypyc_self__, type, value, 
     r34 :: short_int
     r35, r36, r37 :: object
     r38, r39 :: bool
-    r40, r41, r42 :: object
-    r43 :: int
-    r44 :: bool
-    r45 :: int
-    r46 :: object
-    r47 :: short_int
-    r48 :: bool
-    r49 :: object
-    r50, r51, r52 :: bool
-    r53 :: None
-    r54 :: object
-    r55 :: short_int
-    r56, r57 :: bool
-    r58 :: short_int
-    r59 :: bool
-    r60 :: short_int
-    r61 :: bool
-    r62 :: short_int
-    r63, r64 :: bool
+    r40, r41 :: object
+    r42 :: int
+    r43 :: bool
+    r44 :: int
+    r45 :: object
+    r46 :: short_int
+    r47 :: bool
+    r48 :: object
+    r49, r50, r51 :: bool
+    r52 :: None
+    r53 :: object
+    r54 :: short_int
+    r55, r56 :: bool
+    r57 :: short_int
+    r58 :: bool
+    r59 :: short_int
+    r60 :: bool
+    r61 :: short_int
+    r62, r63 :: bool
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.__mypyc_next_label__
@@ -1898,46 +1898,45 @@ L14:
     r41 = next r40 :: object
     if is_error(r41) goto L20 else goto L15
 L15:
-    r42 = cast(object, r41)
-    r43 = unbox(int, r42)
-    r0.i = r43; r44 = is_error
-    r45 = r0.i
-    r46 = box(int, r45)
-    r47 = 2
-    r0.__mypyc_next_label__ = r47; r48 = is_error
-    return r46
+    r42 = unbox(int, r41)
+    r0.i = r42; r43 = is_error
+    r44 = r0.i
+    r45 = box(int, r44)
+    r46 = 2
+    r0.__mypyc_next_label__ = r46; r47 = is_error
+    return r45
 L16:
-    r49 = builtins.None :: object
-    r50 = type is not r49
-    if r50 goto L17 else goto L18 :: bool
+    r48 = builtins.None :: object
+    r49 = type is not r48
+    if r49 goto L17 else goto L18 :: bool
 L17:
-    raise_exception_with_tb(type, value, traceback); r51 = 0
+    raise_exception_with_tb(type, value, traceback); r50 = 0
     unreachable
 L18:
 L19:
     goto L14
 L20:
-    r52 = no_err_occurred
+    r51 = no_err_occurred
 L21:
-    r53 = None
-    r54 = box(None, r53)
-    r55 = -1
-    r0.__mypyc_next_label__ = r55; r56 = is_error
+    r52 = None
+    r53 = box(None, r52)
+    r54 = -1
+    r0.__mypyc_next_label__ = r54; r55 = is_error
 L22:
-    raise StopIteration(r54)
+    raise StopIteration(r53)
     unreachable
 L23:
-    r58 = 0
-    r59 = r1 == r58 :: int
-    if r59 goto L1 else goto L24 :: bool
+    r57 = 0
+    r58 = r1 == r57 :: int
+    if r58 goto L1 else goto L24 :: bool
 L24:
-    r60 = 1
-    r61 = r1 == r60 :: int
-    if r61 goto L7 else goto L25 :: bool
+    r59 = 1
+    r60 = r1 == r59 :: int
+    if r60 goto L7 else goto L25 :: bool
 L25:
-    r62 = 2
-    r63 = r1 == r62 :: int
-    if r63 goto L16 else goto L26 :: bool
+    r61 = 2
+    r62 = r1 == r61 :: int
+    if r62 goto L16 else goto L26 :: bool
 L26:
     raise StopIteration
     unreachable

--- a/test-data/genops-statements.test
+++ b/test-data/genops-statements.test
@@ -289,7 +289,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0, r1 :: object
-    r2, key :: int
+    key, r2 :: int
     r3, r4 :: object
     r5 :: int
     r6 :: bool
@@ -329,7 +329,7 @@ def sum_over_even_values(d):
     r0 :: short_int
     s :: int
     r1, r2 :: object
-    r3, key :: int
+    key, r3 :: int
     r4, r5 :: object
     r6 :: int
     r7 :: short_int
@@ -854,7 +854,7 @@ def g(x):
     i :: int
     r0 :: short_int
     r1, r2 :: object
-    r3, n :: int
+    n, r3 :: int
     r4, r5 :: short_int
     r6 :: bool
     r7 :: None
@@ -900,7 +900,7 @@ def f(a, b):
     r4 :: bool
     r5, r6 :: object
     x, r7 :: int
-    r8, y, r9 :: bool
+    y, r8, r9 :: bool
     r10, r11, r12 :: short_int
     r13 :: bool
     r14 :: None
@@ -945,7 +945,7 @@ def g(a, b):
     z :: int
     r5 :: object
     r6 :: short_int
-    r7, r8, r9, x :: bool
+    r7, r8, x, r9 :: bool
     r10 :: object
     y, r11 :: int
     r12 :: bool

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -806,7 +806,7 @@ def f(d: Dict[int, int]) -> None:
 def f(d):
     d :: dict
     r0, r1 :: object
-    r2, key :: int
+    key, r2 :: int
     r3, r4 :: object
     r5 :: int
     r6 :: bool

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3950,3 +3950,15 @@ def test():
     assert x == y
 
 test()
+
+[case testIterTypeTrickiness]
+# Test inferring the type of a for loop body doesn't cause us grief
+# Extracted from something that broke in mypy
+
+def foo(x: object) -> None:
+    if isinstance(x, dict):
+        for a in x:
+            pass
+
+[file driver.py]
+# really I only care it builds


### PR DESCRIPTION
This reverts commit 0f4afaf1c25081852103149a6811dd73d898f527.

This commit broke compilation of mypy, unfortunately.

The problem seems to be that calling `analyze_iterable_item_type`
isn't really safe to do, since it depends on the state of the
typechecker. In particular, if the type is changed by an `isinstance`
check, we won't figure that out.