### PR TITLE
Support keyword only arguments

### DIFF
--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -9,6 +9,9 @@ from mypyc.ops import (
     FUNC_STATICMETHOD,
 )
 from mypyc.namegen import NameGenerator
+
+from mypy.nodes import ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED
+
 from typing import List, Optional
 
 
@@ -32,25 +35,40 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
         arg = real_args.pop(0)
         emitter.emit_line('PyObject *obj_{} = self;'.format(arg.name))
 
-    optional_args = [arg for arg in fn.args if arg.optional]
+    # Need to order args as: required, optional, kwonly optional, kwonly required
+    # This is because CPyArg_ParseTupleAndKeywords format string requires
+    # them grouped in that way.
+    required_pos = [arg for arg in real_args if arg.kind == ARG_POS]
+    optional_pos = [arg for arg in real_args if arg.kind == ARG_OPT]
+    optional_kwonly = [arg for arg in real_args if arg.kind == ARG_NAMED_OPT]
+    required_kwonly = [arg for arg in real_args if arg.kind == ARG_NAMED]
+
+    reordered_args = required_pos + optional_pos + optional_kwonly + required_kwonly
 
     arg_names = ''.join('"{}", '.format(arg.name) for arg in real_args)
     emitter.emit_line('static char *kwlist[] = {{{}0}};'.format(arg_names))
     for arg in real_args:
         emitter.emit_line('PyObject *obj_{}{};'.format(
                           arg.name, ' = NULL' if arg.optional else ''))
-    arg_format = '{}{}:{}'.format(
-        'O' * (len(real_args) - len(optional_args)),
-        '|' + 'O' * len(optional_args) if len(optional_args) > 0 else '',
-        fn.name,
-    )
+
+    # Construct the format string. Each group requires the previous
+    # groups delimiters to be present first.
+    main_format = 'O' * len(required_pos)
+    if optional_pos or optional_kwonly or required_kwonly:
+        main_format += '|' + 'O' * len(optional_pos)
+    if optional_kwonly or required_kwonly:
+        main_format += '$' + 'O' * len(optional_kwonly)
+    if required_kwonly:
+        main_format += '@' + 'O' * len(required_kwonly)
+
+    arg_format = '{}:{}'.format(main_format, fn.name)
     arg_ptrs = ''.join(', &obj_{}'.format(arg.name) for arg in real_args)
     emitter.emit_lines(
         'if (!CPyArg_ParseTupleAndKeywords(args, kw, "{}", kwlist{})) {{'.format(
             arg_format, arg_ptrs),
         'return NULL;',
         '}')
-    generate_wrapper_core(fn, emitter, optional_args)
+    generate_wrapper_core(fn, emitter, optional_pos + optional_kwonly)
     emitter.emit_line('}')
 
 

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -45,7 +45,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
 
     reordered_args = required_pos + optional_pos + optional_kwonly + required_kwonly
 
-    arg_names = ''.join('"{}", '.format(arg.name) for arg in real_args)
+    arg_names = ''.join('"{}", '.format(arg.name) for arg in reordered_args)
     emitter.emit_line('static char *kwlist[] = {{{}0}};'.format(arg_names))
     for arg in real_args:
         emitter.emit_line('PyObject *obj_{}{};'.format(
@@ -62,7 +62,7 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
         main_format += '@' + 'O' * len(required_kwonly)
 
     arg_format = '{}:{}'.format(main_format, fn.name)
-    arg_ptrs = ''.join(', &obj_{}'.format(arg.name) for arg in real_args)
+    arg_ptrs = ''.join(', &obj_{}'.format(arg.name) for arg in reordered_args)
     emitter.emit_lines(
         'if (!CPyArg_ParseTupleAndKeywords(args, kw, "{}", kwlist{})) {{'.format(
             arg_format, arg_ptrs),

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1324,18 +1324,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         if any(kind in (ARG_STAR, ARG_STAR2) for kind in kinds):
             self.error('Accepting *args or **kwargs is unimplemented', fitem.line)
 
-        # Disallow required kwonly args appearing after optional ones,
-        # since we would miscompile the C API wrappers.
-        seen_optional = False
-        for kind in kinds:
-            if kind in (ARG_OPT, ARG_NAMED_OPT):
-                seen_optional = True
-            if kind == ARG_NAMED and seen_optional:
-                self.error(
-                    'Required keyword-only args that appear after optional args are unimplemented',
-                    fitem.line)
-                break
-
         if fitem.is_coroutine:
             self.error('async functions are unimplemented', fitem.line)
 

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -176,9 +176,6 @@ d1 = {1: 2}
 async def aio(x: Any) -> Any:  # E: async functions are unimplemented
     await x  # E: await is unimplemented
 
-def kwonly1(x: int = 0, *, y: int) -> None: pass  # E: Required keyword-only args that appear after optional args are unimplemented
-def kwonly2(*, x: int = 0, y: int) -> None: pass  # E: Required keyword-only args that appear after optional args are unimplemented
-
 a, *b, c = [1, 2, 3, 4]  # E: Unpacking with * is unimplemented
 
 [file foo/__init__.py]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3968,11 +3968,15 @@ from typing import Tuple
 
 def kwonly1(x: int = 0, *, y: int) -> Tuple[int, int]:
     return x, y
+
 def kwonly2(*, x: int = 0, y: int) -> Tuple[int, int]:
     return x, y
 
 def kwonly3(a: int, b: int = 0, *, y: int, x: int = 1) -> Tuple[int, int, int, int]:
     return a, b, x, y
+
+def kwonly4(*, x: int, y: int) -> Tuple[int, int]:
+    return x, y
 
 [file testutil.py]
 # TODO: This should go into some general mypyc test support lib (along
@@ -3991,7 +3995,7 @@ def assertRaises(typ: type, msg: str = '') -> Iterator[None]:
         assert False, "Expected {} but got no exception".format(typ.__name__)
 
 [file driver.py]
-from native import kwonly1, kwonly2, kwonly3
+from native import kwonly1, kwonly2, kwonly3, kwonly4
 from testutil import assertRaises
 
 assert kwonly1(10, y=20) == (10, 20)
@@ -4025,3 +4029,13 @@ with assertRaises(TypeError, "missing required argument 'a'"):
     kwonly3(b=30, x=40, y=20)
 with assertRaises(TypeError, "missing required keyword-only argument 'y'"):
     kwonly3(10)
+
+assert kwonly4(x=1, y=2) == (1, 2)
+assert kwonly4(y=2, x=1) == (1, 2)
+
+with assertRaises(TypeError, "missing required keyword-only argument 'y'"):
+    kwonly4(x=1)
+with assertRaises(TypeError, "missing required keyword-only argument 'x'"):
+    kwonly4(y=1)
+with assertRaises(TypeError, "missing required keyword-only argument 'x'"):
+    kwonly4()

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3971,7 +3971,7 @@ def kwonly1(x: int = 0, *, y: int) -> Tuple[int, int]:
 def kwonly2(*, x: int = 0, y: int) -> Tuple[int, int]:
     return x, y
 
-def kwonly3(a: int, b: int = 0, *, x: int = 1, y: int) -> Tuple[int, int, int, int]:
+def kwonly3(a: int, b: int = 0, *, y: int, x: int = 1) -> Tuple[int, int, int, int]:
     return a, b, x, y
 
 [file testutil.py]

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3962,3 +3962,66 @@ def foo(x: object) -> None:
 
 [file driver.py]
 # really I only care it builds
+
+[case testKeywordOnly]
+from typing import Tuple
+
+def kwonly1(x: int = 0, *, y: int) -> Tuple[int, int]:
+    return x, y
+def kwonly2(*, x: int = 0, y: int) -> Tuple[int, int]:
+    return x, y
+
+def kwonly3(a: int, b: int = 0, *, x: int = 1, y: int) -> Tuple[int, int, int, int]:
+    return a, b, x, y
+
+[file testutil.py]
+# TODO: This should go into some general mypyc test support lib (along
+# with other things)
+from contextlib import contextmanager
+from typing import Iterator
+
+@contextmanager
+def assertRaises(typ: type, msg: str = '') -> Iterator[None]:
+    try:
+        yield
+    except Exception as e:
+        assert isinstance(e, typ), "{} is not a {}".format(e, typ.__name__)
+        assert msg in str(e), 'Message "{}" does not match "{}"'.format(e, msg)
+    else:
+        assert False, "Expected {} but got no exception".format(typ.__name__)
+
+[file driver.py]
+from native import kwonly1, kwonly2, kwonly3
+from testutil import assertRaises
+
+assert kwonly1(10, y=20) == (10, 20)
+assert kwonly1(y=20) == (0, 20)
+with assertRaises(TypeError, "missing required keyword-only argument 'y'"):
+    kwonly1()
+with assertRaises(TypeError, "takes at most 1 positional argument (2 given)"):
+    kwonly1(10, 20)
+
+assert kwonly2(x=10, y=20) == (10, 20)
+assert kwonly2(y=20) == (0, 20)
+
+with assertRaises(TypeError, "missing required keyword-only argument 'y'"):
+    kwonly2()
+with assertRaises(TypeError, "takes no positional arguments"):
+    kwonly2(10, 20)
+
+assert kwonly3(10, y=20) == (10, 0, 1, 20)
+assert kwonly3(a=10, y=20) == (10, 0, 1, 20)
+assert kwonly3(10, 30, y=20) == (10, 30, 1, 20)
+assert kwonly3(10, b=30, y=20) == (10, 30, 1, 20)
+assert kwonly3(a=10, b=30, y=20) == (10, 30, 1, 20)
+
+assert kwonly3(10, x=40, y=20) == (10, 0, 40, 20)
+assert kwonly3(a=10, x=40, y=20) == (10, 0, 40, 20)
+assert kwonly3(10, 30, x=40, y=20) == (10, 30, 40, 20)
+assert kwonly3(10, b=30, x=40, y=20) == (10, 30, 40, 20)
+assert kwonly3(a=10, b=30, x=40, y=20) == (10, 30, 40, 20)
+
+with assertRaises(TypeError, "missing required argument 'a'"):
+    kwonly3(b=30, x=40, y=20)
+with assertRaises(TypeError, "missing required keyword-only argument 'y'"):
+    kwonly3(10)


### PR DESCRIPTION
Two parts of this:
 * Add support to getargs for keyword only arguments, using `$` to indicate their start
 * Use that support by properly grouping arguments by their kind

Closes #176.