### PR TITLE
Use Py_BuildValue rather than a loop

### DIFF
--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -28,12 +28,13 @@ func_op(
 
 
 def emit_new(emitter: EmitterInterface, args: List[str], dest: str) -> None:
-    # TODO: This would be better split into multiple smaller ops.
-    emitter.emit_line('%s = PyList_New(%d); ' % (dest, len(args)))
-    emitter.emit_line('if (likely(%s != NULL)) {' % dest)
-    for i, arg in enumerate(args):
-        emitter.emit_line('PyList_SET_ITEM(%s, %s, %s);' % (dest, i, arg))
-    emitter.emit_line('}')
+    if args:
+        fmt = ''.join(['O' for arg in args])
+        values = ', '.join(args)
+        emitter.emit_line('%s = Py_BuildValue("[%s]", %s); ' %
+                          (dest, fmt, values))
+    else:
+        emitter.emit_line('%s = PyList_New(%d); ' % (dest, 0))
 
 
 new_list_op = custom_op(arg_types=[object_rprimitive],

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -180,12 +180,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_new_list(self) -> None:
         self.assert_emit(PrimitiveOp([self.n, self.m], new_list_op, 55),
-                         """cpy_r_r0 = PyList_New(2);
-                            if (likely(cpy_r_r0 != NULL)) {
-                                PyList_SET_ITEM(cpy_r_r0, 0, cpy_r_n);
-                                PyList_SET_ITEM(cpy_r_r0, 1, cpy_r_m);
-                            }
-                         """)
+                         """cpy_r_r0 = Py_BuildValue("[o,o]", cpy_r_n, cpy_r_m);""")
 
     def test_list_append(self) -> None:
         self.assert_emit(PrimitiveOp([self.l, self.o], list_append_op, 1),


### PR DESCRIPTION
I originally thought the intended result was : 
    "x = [ 10, 20, 30 ]"   =>   "dest = Py_BuildValue("[iii]", 10, 20, 30)"
Given the existence of issue "#599 Replace registers with constants when the value is a known compile-time constant", I believe the intent to be :
    "x = [ 10, 20, 30 ]"   =>   "dest = Py_BuildValue("[iii]", r1, r2, r3)"
Please advise if I erred.
Thanks
