### PR TITLE
Bump mypy pin

### DIFF
--- a/test-data/analysis.test
+++ b/test-data/analysis.test
@@ -499,7 +499,8 @@ L3:
 (3, 0)   {a}                     {a}
 
 [case testError]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined
+def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+                                  # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testExceptUndefined_Liveness]
 def lol(x: object) -> int:

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -140,8 +140,9 @@ def decorator(x: Any) -> Any:
 class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented
     pass
 
-@decorator  # E: Metaclasses are not supported  # E: Class decorators are not supported
-class Wrong(metaclass=NeverMetaclass):
+@decorator
+class Wrong(metaclass=NeverMetaclass):  # E: Metaclasses are not supported  \
+                                        # E: Class decorators are not supported
     pass
 
 class Concrete1:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -404,7 +404,8 @@ def f() -> None:
     return 1 # E: No return value expected
 
 [case testReportSemanticaAnalysisError1]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined
+def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+                                  # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testReportSemanticaAnalysisError2]
 def f() -> None:

--- a/test-data/module-output.test
+++ b/test-data/module-output.test
@@ -151,3 +151,4 @@ char CPyDef___top_level__(void);
 def f(x: List[int]) -> None: pass
 [out]
 prog.py:1: error: Name 'List' is not defined
+prog.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import List")

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -590,7 +590,8 @@ L0:
     return r2
 
 [case testError]
-def f(x: List[int]) -> None: pass # E: Name 'List' is not defined
+def f(x: List[int]) -> None: pass # E: Name 'List' is not defined \
+                                  # N: Did you forget to import it from "typing"? (Suggestion: "from typing import List")
 
 [case testNewList]
 def f() -> int:


### PR DESCRIPTION
This commit bumps the pinned version of mypy, mainly to verify the [recent changes] to the semantics of the `Instance.final_value` have not broken mypyc in any way. (It turned out mypyc was actually using the `Var.final_value` field, which has the same name by coincidence.)

This commit also makes a few fixes to the tests to incorporate some of the recent changes made in our error messages during the pycon sprints.

  [0]: https://github.com/python/mypy/pull/6763