### PR TITLE
Only use primitives for method calls using only positional args

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2605,9 +2605,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                           arg_kinds, arg_names)
 
         # Try to do a special-cased method call
-        target = self.translate_special_method_call(base, name, arg_values, return_rtype, line)
-        if target:
-            return target
+        if not arg_kinds or arg_kinds == [ARG_POS] * len(arg_values):
+            target = self.translate_special_method_call(base, name, arg_values, return_rtype, line)
+            if target:
+                return target
 
         # Fall back to Python method call
         return self.py_method_call(base, name, arg_values, base.line, arg_kinds, arg_names)

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -116,7 +116,12 @@ class dict(Mapping[K, V]):
     def __contains__(self, item: object) -> bool: pass
     def __iter__(self) -> Iterator[K]: pass
     def __len__(self) -> int: pass
-    def update(self, a: Mapping[K, V]) -> None: pass
+    @overload
+    def update(self, __m: Mapping[K, V], **kwargs: V) -> None: pass
+    @overload
+    def update(self, __m: Iterable[Tuple[K, V]], **kwargs: V) -> None: ...
+    @overload
+    def update(self, **kwargs: V) -> None: ...
     def pop(self, x: int) -> K: pass
     def keys(self) -> List[K]: pass
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -885,6 +885,10 @@ def make_dict1(x: Any) -> Dict[Any, Any]:
 def make_dict2(x: Dict[Any, Any]) -> Dict[Any, Any]:
     return dict(x)
 
+def u(x: int) -> int:
+    d = {} # type: Dict[str, int]
+    d.update(x=x)
+    return d['x']
 
 [file defaultdictwrap.py]
 from typing import Dict
@@ -893,7 +897,7 @@ def make_dict() -> Dict[str, int]:
     return defaultdict(int)
 
 [file driver.py]
-from native import f, g, h, make_dict1, make_dict2, update_dict
+from native import f, g, h, u, make_dict1, make_dict2, update_dict
 assert f(1) == 2
 assert f(2) == 1
 assert g() == 30
@@ -913,6 +917,8 @@ assert make_dict1(object.__dict__) == dict(object.__dict__)
 d = {}
 update_dict(d, object.__dict__)
 assert d == dict(object.__dict__)
+
+assert u(10) == 10
 
 [case testPyMethodCall]
 from typing import List


### PR DESCRIPTION
This was causing us to miscompile `dict.update(foo=...)`