### PR TITLE
Accept relative imports

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -22,6 +22,7 @@ if MYPY:
 from abc import abstractmethod
 import sys
 import traceback
+import importlib.util
 import itertools
 
 from mypy.build import Graph
@@ -1133,13 +1134,17 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
     def visit_import_from(self, node: ImportFrom) -> None:
         if node.is_mypy_only:
             return
-        # TODO support these?
-        if node.relative:
-            self.error("Relative imports are unimplemented", node.line)
-            return
 
-        self.gen_import(node.id, node.line)
-        module = self.add(LoadStatic(object_rprimitive, 'module', node.id))
+        module_state = self.graph[self.module_name]
+        if module_state.ancestors is not None and module_state.ancestors:
+            module_package = module_state.ancestors[0]
+        else:
+            module_package = ''
+
+        id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
+
+        self.gen_import(id, node.line)
+        module = self.add(LoadStatic(object_rprimitive, 'module', id))
 
         # Copy everything into our module's dict.
         # Note that we miscompile import from inside of functions here,
@@ -1149,8 +1154,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         for name, maybe_as_name in node.names:
             # If one of the things we are importing is a module,
             # import it as a module also.
-            fullname = node.id + '.' + name
-            if fullname in self.graph or fullname in self.graph[self.module_name].suppressed:
+            fullname = id + '.' + name
+            if fullname in self.graph or fullname in module_state.suppressed:
                 self.gen_import(fullname, node.line)
 
             as_name = maybe_as_name or name

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -95,7 +95,7 @@ def f(x: int) -> int:
     return x*x
 
 [case testErrorOutput]
-# cmd: test.py foo/__init__.py
+# cmd: test.py
 
 [file test.py]
 from typing import List, Any
@@ -172,6 +172,3 @@ async def aio(x: Any) -> Any:  # E: async functions are unimplemented
     await x  # E: await is unimplemented
 
 a, *b, c = [1, 2, 3, 4]  # E: Unpacking with * is unimplemented
-
-[file foo/__init__.py]
-x = 20

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -95,7 +95,7 @@ def f(x: int) -> int:
     return x*x
 
 [case testErrorOutput]
-# cmd: test.py foo/__init__.py foo/bar.py
+# cmd: test.py foo/__init__.py
 
 [file test.py]
 from typing import List, Any
@@ -175,6 +175,3 @@ a, *b, c = [1, 2, 3, 4]  # E: Unpacking with * is unimplemented
 
 [file foo/__init__.py]
 x = 20
-
-[file foo/bar.py]
-from . import x  # E: Relative imports are unimplemented

--- a/test-data/run-multimodule.test
+++ b/test-data/run-multimodule.test
@@ -463,6 +463,29 @@ except TypeError:
 else:
     assert False
 
+[case testMultiModuleRelative]
+from package.a import f
+[file package/__init__.py]
+[file package/a.py]
+from . import b
+from .c import c3
+def f() -> None:
+    print("Hello " + b.b2())
+    print("Hello " + c3())
+[file package/b.py]
+def b2() -> str:
+    return "moon!"
+[file package/c.py]
+def c3() -> str:
+    return "sun!"
+
+[file driver.py]
+from native import f
+f()
+[out]
+Hello moon!
+Hello sun!
+
 [case testMultiModuleCrash]
 b = False
 if b:


### PR DESCRIPTION
Two ways to do this:

1. Resolve relative imports at compile time like this
2. Defer to `pyimport_importmodulelevelobject`, so theoretically a package using entirely relative imports can be movied around so that it's importable under a different path.

I implemented the second, but it was excessively complicated and didn't provide any benefit, as I'm pretty sure the typechecking results rely on the module being under the usual path, so switched to this.