### PR TITLE
Add a new_tuple_op for constructing tuple_rprimitive

### DIFF
--- a/mypyc/ops_primitive.py
+++ b/mypyc/ops_primitive.py
@@ -29,13 +29,22 @@ name_ref_ops = {}  # type: Dict[str, OpDescription]
 def simple_emit(template: str) -> EmitCallback:
     """Construct a simple PrimitiveOp emit callback function.
 
-    It just applies a str.format template to 'args', 'dest', and 'comma_args'.
+    It just applies a str.format template to
+    'args', 'dest', 'comma_args', 'num_args', 'pre_comma_args'.
 
     For more complex cases you need to define a custom function.
     """
 
     def emit(emitter: EmitterInterface, args: List[str], dest: str) -> None:
-        emitter.emit_line(template.format(args=args, dest=dest, comma_args=', '.join(args)))
+        comma_args = ', '.join(args)
+        pre_comma_args = ', ' + comma_args if comma_args else ''
+
+        emitter.emit_line(template.format(
+            args=args,
+            dest=dest,
+            comma_args=comma_args,
+            pre_comma_args=pre_comma_args,
+            num_args=len(args)))
 
     return emit
 

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -11,7 +11,7 @@ from mypyc.ops import (
     object_rprimitive, ERR_NEVER, ERR_MAGIC
 )
 from mypyc.ops_primitive import (
-    func_op, method_op, call_emit,
+    func_op, method_op, custom_op, call_emit, simple_emit,
 )
 
 
@@ -21,6 +21,16 @@ tuple_get_item_op = method_op(
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
     emit=call_emit('CPySequenceTuple_GetItem'))
+
+
+new_tuple_op = custom_op(
+    arg_types=[object_rprimitive],
+    result_type=tuple_rprimitive,
+    is_var_arg=True,
+    error_kind=ERR_MAGIC,
+    steals=False,
+    format_str='{dest} = ({comma_args}) :: tuple',
+    emit=simple_emit('{dest} = PyTuple_Pack({num_args}{pre_comma_args});'))
 
 
 def emit_len(emitter: EmitterInterface, args: List[str], dest: str) -> None:

--- a/test-data/genops-basic.test
+++ b/test-data/genops-basic.test
@@ -1089,24 +1089,23 @@ def call_python_function_with_keyword_arg(x):
     r0 :: short_int
     r1 :: object
     r2 :: str
-    r3 :: tuple[str]
+    r3 :: tuple
     r4 :: dict
     r5 :: object
     r6 :: bool
-    r7, r8 :: object
-    r9 :: int
+    r7 :: object
+    r8 :: int
 L0:
     r0 = 2
     r1 = int
     r2 = unicode_3 :: static  ('base')
-    r3 = (x)
+    r3 = (x) :: tuple
     r4 = {}
     r5 = box(short_int, r0)
     r6 = r4.__setitem__(r2, r5) :: dict
-    r7 = box(tuple[str], r3)
-    r8 = py_call_with_kwargs(r1, r7, r4)
-    r9 = unbox(int, r8)
-    return r9
+    r7 = py_call_with_kwargs(r1, r3, r4)
+    r8 = unbox(int, r7)
+    return r8
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second :: int
@@ -1114,50 +1113,50 @@ def call_python_method_with_keyword_args(xs, first, second):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4 :: tuple[int]
-    r5 :: dict
-    r6 :: object
-    r7 :: bool
-    r8, r9 :: object
+    r4 :: object
+    r5 :: tuple
+    r6 :: dict
+    r7 :: object
+    r8 :: bool
+    r9 :: object
     r10 :: None
     r11 :: short_int
     r12 :: str
     r13 :: object
     r14, r15 :: str
-    r16 :: tuple[]
+    r16 :: tuple
     r17 :: dict
     r18 :: object
     r19 :: bool
     r20 :: object
     r21 :: bool
-    r22, r23 :: object
-    r24 :: None
+    r22 :: object
+    r23 :: None
 L0:
     r0 = 0
     r1 = unicode_4 :: static  ('insert')
     r2 = getattr xs, r1
     r3 = unicode_5 :: static  ('x')
-    r4 = (r0)
-    r5 = {}
-    r6 = box(int, first)
-    r7 = r5.__setitem__(r3, r6) :: dict
-    r8 = box(tuple[int], r4)
-    r9 = py_call_with_kwargs(r2, r8, r5)
+    r4 = box(short_int, r0)
+    r5 = (r4) :: tuple
+    r6 = {}
+    r7 = box(int, first)
+    r8 = r6.__setitem__(r3, r7) :: dict
+    r9 = py_call_with_kwargs(r2, r5, r6)
     r10 = unbox(None, r9)
     r11 = 1
     r12 = unicode_4 :: static  ('insert')
     r13 = getattr xs, r12
     r14 = unicode_5 :: static  ('x')
     r15 = unicode_6 :: static  ('i')
-    r16 = ()
+    r16 = () :: tuple
     r17 = {}
     r18 = box(int, second)
     r19 = r17.__setitem__(r14, r18) :: dict
     r20 = box(short_int, r11)
     r21 = r17.__setitem__(r15, r20) :: dict
-    r22 = box(tuple[], r16)
-    r23 = py_call_with_kwargs(r13, r22, r17)
-    r24 = unbox(None, r23)
+    r22 = py_call_with_kwargs(r13, r16, r17)
+    r23 = unbox(None, r22)
     return xs
 
 [case testObjectAsBoolean]
@@ -1625,11 +1624,11 @@ def g():
     r13 :: dict
     r14 :: str
     r15 :: object
-    r16 :: tuple[]
+    r16 :: tuple
     r17 :: dict
     r18 :: bool
-    r19, r20 :: object
-    r21 :: tuple[int, int, int]
+    r19 :: object
+    r20 :: tuple[int, int, int]
 L0:
     r0 = unicode_3 :: static  ('a')
     r1 = 1
@@ -1647,13 +1646,12 @@ L0:
     r13 = __main__.globals :: static
     r14 = unicode_6 :: static  ('f')
     r15 = r13[r14] :: dict
-    r16 = ()
+    r16 = () :: tuple
     r17 = {}
     r18 = r17.update(r6) (display) :: dict
-    r19 = box(tuple[], r16)
-    r20 = py_call_with_kwargs(r15, r19, r17)
-    r21 = unbox(tuple[int, int, int], r20)
-    return r21
+    r19 = py_call_with_kwargs(r15, r16, r17)
+    r20 = unbox(tuple[int, int, int], r19)
+    return r20
 def h():
     r0 :: short_int
     r1 :: str
@@ -1667,11 +1665,11 @@ def h():
     r9 :: bool
     r10 :: dict
     r11 :: str
-    r12 :: object
-    r13 :: tuple[int]
-    r14 :: dict
-    r15 :: bool
-    r16, r17 :: object
+    r12, r13 :: object
+    r14 :: tuple
+    r15 :: dict
+    r16 :: bool
+    r17 :: object
     r18 :: tuple[int, int, int]
 L0:
     r0 = 1
@@ -1687,11 +1685,11 @@ L0:
     r10 = __main__.globals :: static
     r11 = unicode_6 :: static  ('f')
     r12 = r10[r11] :: dict
-    r13 = (r0)
-    r14 = {}
-    r15 = r14.update(r5) (display) :: dict
-    r16 = box(tuple[int], r13)
-    r17 = py_call_with_kwargs(r12, r16, r14)
+    r13 = box(short_int, r0)
+    r14 = (r13) :: tuple
+    r15 = {}
+    r16 = r15.update(r5) (display) :: dict
+    r17 = py_call_with_kwargs(r12, r14, r15)
     r18 = unbox(tuple[int, int, int], r17)
     return r18
 

--- a/test-data/genops-classes.test
+++ b/test-data/genops-classes.test
@@ -383,15 +383,14 @@ def __top_level__():
     r60 :: dict
     r61 :: str
     r62, r63 :: object
-    r64 :: tuple[object, object, object]
-    r65 :: object
-    r66 :: str
-    r67, r68 :: object
-    r69 :: bool
-    r70 :: dict
-    r71 :: str
-    r72 :: bool
-    r73 :: None
+    r64 :: tuple
+    r65 :: str
+    r66, r67 :: object
+    r68 :: bool
+    r69 :: dict
+    r70 :: str
+    r71 :: bool
+    r72 :: None
 L0:
     r0 = builtins.module :: static
     r1 = builtins.None :: object
@@ -471,18 +470,17 @@ L6:
     r61 = unicode_6 :: static  ('T')
     r62 = r60[r61] :: dict
     r63 = r59[r62] :: object
-    r64 = (r55, r56, r63)
-    r65 = box(tuple[object, object, object], r64)
-    r66 = unicode_7 :: static  ('__main__')
-    r67 = __main__.D_template :: type
-    r68 = pytype_from_template(r67, r65, r66)
-    r69 = D_trait_vtable_setup()
-    __main__.D = r68 :: type
-    r70 = __main__.globals :: static
-    r71 = unicode_10 :: static  ('D')
-    r72 = r70.__setitem__(r71, r68) :: dict
-    r73 = None
-    return r73
+    r64 = (r55, r56, r63) :: tuple
+    r65 = unicode_7 :: static  ('__main__')
+    r66 = __main__.D_template :: type
+    r67 = pytype_from_template(r66, r64, r65)
+    r68 = D_trait_vtable_setup()
+    __main__.D = r67 :: type
+    r69 = __main__.globals :: static
+    r70 = unicode_10 :: static  ('D')
+    r71 = r69.__setitem__(r70, r67) :: dict
+    r72 = None
+    return r72
 
 [case testIsInstance]
 class A: pass

--- a/test-data/refcount.test
+++ b/test-data/refcount.test
@@ -754,28 +754,27 @@ def g(x):
     r0 :: short_int
     r1 :: object
     r2 :: str
-    r3 :: tuple[str]
+    r3 :: tuple
     r4 :: dict
     r5 :: object
     r6 :: bool
-    r7, r8 :: object
-    r9 :: int
+    r7 :: object
+    r8 :: int
 L0:
     r0 = 2
     r1 = int
     r2 = unicode_1 :: static  ('base')
-    r3 = (x)
+    r3 = (x) :: tuple
     r4 = {}
     r5 = box(short_int, r0)
     r6 = r4.__setitem__(r2, r5) :: dict
     dec_ref r5
-    r7 = box(tuple[str], r3)
-    r8 = py_call_with_kwargs(r1, r7, r4)
-    dec_ref r7
+    r7 = py_call_with_kwargs(r1, r3, r4)
+    dec_ref r3
     dec_ref r4
-    r9 = unbox(int, r8)
-    dec_ref r8
-    return r9
+    r8 = unbox(int, r7)
+    dec_ref r7
+    return r8
 
 [case testListAppend]
 from typing import List


### PR DESCRIPTION
We use this to avoid generating a bunch of boxing code in places we
know we are going to box the tuple. Ideally we would also be able
to detect such situations and avoid the boxing step.