### PR TITLE
Add fastcall and load_static_tuple

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1604,7 +1604,12 @@ class ClassIR:
         return sorted(concrete, key=lambda c: (len(c.children), c.name))
 
 
-LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
+BaseLiteral = Union[int, float, complex, str, bytes]
+BaseLiteralKey = Tuple[Type[object], BaseLiteral]
+
+Literal = Union[BaseLiteral, Tuple[BaseLiteral, ...]]
+LiteralKey =Tuple[Type[object], Union[BaseLiteral, Tuple[str, ...]]]
+LiteralsMap = Dict[LiteralKey, str] # but ordered
 
 
 class ModuleIR:


### PR DESCRIPTION
I have not managed to get a benchmark where this is faster.

Test source:

```python
from typing import Any

def bigcall(g:Any) -> None:
    for _ in range(1000):
        g('0','1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49', a='a',b='b',c='c',d='d',e='e',f='f',g='g',h='h',i='i',j='j',k='k',l='l',m='m',n='n',o='o',p='p',q='q',r='r',s='s',t='t',u='u',v='v',w='w',x='x',y='y',z='z')

def boundmethod(g:Any) -> None:
    for _ in range(1000):
        g('.')

def unboundmethod(g:Any) -> None:
    for _ in range(1000):
        g('abcdef.', '.')

def z(k0:Any, k1:Any, k2:Any, k3:Any, k4:Any, k5:Any, k6:Any, k7:Any, k8:Any, k9:Any, k10:Any, k11:Any, k12:Any, k13:Any, k14:Any, k15:Any, k16:Any, k17:Any, k18:Any, k19:Any, k20:Any, k21:Any, k22:Any, k23:Any, k24:Any, k25:Any, k26:Any, k27:Any, k28:Any, k29:Any, k30:Any, k31:Any, k32:Any, k33:Any, k34:Any, k35:Any, k36:Any, k37:Any, k38:Any, k39:Any, k40:Any, k41:Any, k42:Any, k43:Any, k44:Any, k45:Any, k46:Any, k47:Any, k48:Any, k49:Any, a:Any, b:Any, c:Any, d:Any, e:Any, f:Any, g:Any, h:Any, i:Any, j:Any, k:Any, l:Any, m:Any, n:Any, o:Any, p:Any, q:Any, r:Any, s:Any, t:Any, u:Any, v:Any, w:Any, x:Any, y:Any, z:Any) -> None: pass
```

Timing (master):
```
In [7]: %timeit eg.bigcall(z)  # z defined in the shell
3.75 ms ± 88.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [8]: %timeit eg.bigcall(eg.z)  # z compiled, uses CPyArg_ParseTupleAndKeywords
3.42 ms ± 42.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [9]: %%timeit UB=str.index
   ...: eg.unboundmethod(UB)
   ...:
   ...:


262 µs ± 3.81 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [10]: %%timeit B='abcdef.g'.index
    ...: eg.boundmethod(B)
    ...:
    ...:
203 µs ± 3.04 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

After:

```
In [8]: %timeit eg.bigcall(z)
2.02 ms ± 55.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [9]: %timeit eg.bigcall(eg.z)
3.32 ms ± 63.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [6]: %%timeit UB=str.index
   ...: eg.unboundmethod(UB)
   ...:
255 µs ± 7.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [7]: %%timeit B='abcdef.g'.index
   ...: eg.boundmethod(B)
   ...:
   ...:
197 µs ± 4.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

The following needs to be changed:

* Large arrays of PyObject* are allocated on the stack - they should be allocated dynamically
* Each fastcall creates a separate array of PyObject*, but I imagine the C compiler would notice this and reuse the stack space, but it might not.
* Fastcall was just rejigged in 3.8 today!