### PR TITLE
Add mypyc support for property setters

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -318,7 +318,7 @@ def mypycify(paths: List[str],
         cflags += [
             '-O{}'.format(opt_level), '-Werror', '-Wno-unused-function', '-Wno-unused-label',
             '-Wno-unreachable-code', '-Wno-unused-variable', '-Wno-trigraphs',
-            '-Wno-unused-command-line-argument'
+            '-Wno-unused-command-line-argument', '-Wno-unknown-warning-option',
         ]
         if 'gcc' in compiler.compiler[0]:
             # This flag is needed for gcc but does not exist on clang.

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -5,12 +5,12 @@ REG_PREFIX = 'cpy_r_'  # Registers
 STATIC_PREFIX = 'CPyStatic_'  # Static variables (for literals etc.)
 TYPE_PREFIX = 'CPyType_'  # Type object struct
 ATTR_PREFIX = '_'  # Attributes
-PROPSET_PREFIX = 'CPyPropSet_'
 
 ENV_ATTR_NAME = '__mypyc_env__'
 NEXT_LABEL_ATTR_NAME = '__mypyc_next_label__'
 TEMP_ATTR_NAME = '__mypyc_temp__'
 LAMBDA_NAME = '__mypyc_lambda__'
+PROPSET_PREFIX = '__mypyc_setter__'
 SELF_NAME = '__mypyc_self__'
 INT_PREFIX = '__tmp_literal_int_'
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -5,6 +5,7 @@ REG_PREFIX = 'cpy_r_'  # Registers
 STATIC_PREFIX = 'CPyStatic_'  # Static variables (for literals etc.)
 TYPE_PREFIX = 'CPyType_'  # Type object struct
 ATTR_PREFIX = '_'  # Attributes
+PROPSET_PREFIX = 'CPyPropSet_'
 
 ENV_ATTR_NAME = '__mypyc_env__'
 NEXT_LABEL_ATTR_NAME = '__mypyc_next_label__'

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -529,7 +529,7 @@ def generate_methods_table(cl: ClassIR,
                            emitter: Emitter) -> None:
     emitter.emit_line('static PyMethodDef {}[] = {{'.format(name))
     for fn in cl.methods.values():
-        if fn.name in cl.properties:
+        if fn.decl.is_prop_setter or fn.decl.is_prop_getter:
             continue
         emitter.emit_line('{{"{}",'.format(fn.name))
         emitter.emit_line(' (PyCFunction){}{},'.format(PREFIX, fn.cname(emitter.names)))

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -566,10 +566,18 @@ def generate_getseter_declarations(cl: ClassIR, emitter: Emitter) -> None:
             emitter.emit_line('{}({} *self, PyObject *value, void *closure);'.format(
                 setter_name(cl, attr, emitter.names),
                 cl.struct_name(emitter.names)))
+
     for prop in cl.properties:
+        # Generate getter declaration
         emitter.emit_line('static PyObject *')
         emitter.emit_line('{}({} *self, void *closure);'.format(
             getter_name(cl, prop, emitter.names),
+            cl.struct_name(emitter.names)))
+
+        # Generate setter declaration
+        emitter.emit_line('static int')
+        emitter.emit_line('{}({} *self, PyObject *value, void *closure);'.format(
+            setter_name(cl, prop, emitter.names),
             cl.struct_name(emitter.names)))
 
 
@@ -586,7 +594,14 @@ def generate_getseters_table(cl: ClassIR,
     for prop in cl.properties:
         emitter.emit_line('{{"{}",'.format(prop))
         emitter.emit_line(' (getter){},'.format(getter_name(cl, prop, emitter.names)))
-        emitter.emit_line('NULL, NULL, NULL},')
+
+        setter = cl.properties[prop][1]
+        if setter:
+            emitter.emit_line(' (setter){},'.format(setter_name(cl, prop, emitter.names)))
+            emitter.emit_line('NULL, NULL},')
+        else:
+            emitter.emit_line('NULL, NULL, NULL},')
+
     emitter.emit_line('{NULL}  /* Sentinel */')
     emitter.emit_line('};')
 
@@ -599,10 +614,14 @@ def generate_getseters(cl: ClassIR, emitter: Emitter) -> None:
             generate_setter(cl, attr, rtype, emitter)
             if i < len(cl.attributes) - 1:
                 emitter.emit_line('')
-    for prop, func_ir in cl.properties.items():
-        rtype = func_ir.sig.ret_type
+    for prop, (getter, setter) in cl.properties.items():
+        rtype = getter.sig.ret_type
         emitter.emit_line('')
-        generate_readonly_getter(cl, prop, rtype, func_ir, emitter)
+        generate_readonly_getter(cl, prop, rtype, getter, emitter)
+        if setter:
+            arg_type = setter.sig.args[1].type
+            emitter.emit_line('')
+            generate_property_setter(cl, prop, arg_type, setter, emitter)
 
 
 def generate_getter(cl: ClassIR,
@@ -674,6 +693,31 @@ def generate_readonly_getter(cl: ClassIR,
     else:
         emitter.emit_line('return {}{}((PyObject *) self);'.format(NATIVE_PREFIX,
                                                                    func_ir.cname(emitter.names)))
+    emitter.emit_line('}')
+
+
+def generate_property_setter(cl: ClassIR,
+                             attr: str,
+                             arg_type: RType,
+                             func_ir: FuncIR,
+                             emitter: Emitter) -> None:
+
+    emitter.emit_line('static int')
+    emitter.emit_line('{}({} *self, PyObject *value, void *closure)'.format(
+        setter_name(cl, attr, emitter.names),
+        cl.struct_name(emitter.names)))
+    emitter.emit_line('{')
+    if arg_type.is_unboxed:
+        emitter.emit_unbox('value', 'tmp', arg_type, custom_failure='return -1;',
+                           declare_dest=True)
+        emitter.emit_line('{}{}((PyObject *) self, tmp);'.format(
+                          NATIVE_PREFIX,
+                          func_ir.cname(emitter.names)))
+    else:
+        emitter.emit_line('{}{}((PyObject *) self, value);'.format(
+                          NATIVE_PREFIX,
+                          func_ir.cname(emitter.names)))
+    emitter.emit_line('return 0;')
     emitter.emit_line('}')
 
 

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -529,6 +529,8 @@ def generate_methods_table(cl: ClassIR,
                            emitter: Emitter) -> None:
     emitter.emit_line('static PyMethodDef {}[] = {{'.format(name))
     for fn in cl.methods.values():
+        if fn.name in cl.properties:
+            continue
         emitter.emit_line('{{"{}",'.format(fn.name))
         emitter.emit_line(' (PyCFunction){}{},'.format(PREFIX, fn.cname(emitter.names)))
         flags = ['METH_VARARGS', 'METH_KEYWORDS']
@@ -574,11 +576,12 @@ def generate_getseter_declarations(cl: ClassIR, emitter: Emitter) -> None:
             getter_name(cl, prop, emitter.names),
             cl.struct_name(emitter.names)))
 
-        # Generate setter declaration
-        emitter.emit_line('static int')
-        emitter.emit_line('{}({} *self, PyObject *value, void *closure);'.format(
-            setter_name(cl, prop, emitter.names),
-            cl.struct_name(emitter.names)))
+        # Generate property setter declaration if a setter exists
+        if cl.properties[prop][1]:
+            emitter.emit_line('static int')
+            emitter.emit_line('{}({} *self, PyObject *value, void *closure);'.format(
+                setter_name(cl, prop, emitter.names),
+                cl.struct_name(emitter.names)))
 
 
 def generate_getseters_table(cl: ClassIR,

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -234,7 +234,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
         rtype = op.class_type
         cl = rtype.class_ir
         version = '_TRAIT' if cl.is_trait else ''
-        if cl.is_trait:
+        if cl.is_trait or cl.get_method(op.attr):
             self.emit_line('%s = CPY_SET_ATTR%s(%s, %s, %d, %s, %s, %s); /* %s */' % (
                 dest,
                 version,
@@ -246,6 +246,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
                 self.ctype(rtype.attr_type(op.attr)),
                 op.attr))
         else:
+            print("hello")
             typ, decl_cl = cl.attr_details(op.attr)
             self.emit_line('%s = %s((%s *)%s, %s); /* %s */' % (
                 dest,

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -246,7 +246,6 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
                 self.ctype(rtype.attr_type(op.attr)),
                 op.attr))
         else:
-            print("hello")
             typ, decl_cl = cl.attr_details(op.attr)
             self.emit_line('%s = %s((%s *)%s, %s); /* %s */' % (
                 dest,

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1332,12 +1332,14 @@ class FuncDecl:
                  class_name: Optional[str],
                  module_name: str,
                  sig: FuncSignature,
-                 kind: int = FUNC_NORMAL) -> None:
+                 kind: int = FUNC_NORMAL,
+                 is_prop_setter: bool = False) -> None:
         self.name = name
         self.class_name = class_name
         self.module_name = module_name
         self.sig = sig
         self.kind = kind
+        self.is_prop_setter = is_prop_setter
         if class_name is None:
             self.bound_sig = None  # type: Optional[FuncSignature]
         else:
@@ -1580,15 +1582,15 @@ class ClassIR:
             if name in ir.methods:
                 return ir.methods[name], ir
 
-            if name in ir.properties:
-                return ir.properties[name][0], ir
+            # if name in ir.properties:
+            #     return ir.properties[name][0], ir
 
-            if name.startswith(PROPSET_PREFIX):
-                prop_name = name.split(PROPSET_PREFIX)[1]
-                if prop_name in ir.properties:
-                    setter = ir.properties[prop_name][1]
-                    if setter:
-                        return (setter, ir)
+            # if name.startswith(PROPSET_PREFIX):
+            #     prop_name = name.split(PROPSET_PREFIX)[1]
+            #     if prop_name in ir.properties:
+            #         setter = ir.properties[prop_name][1]
+            #         if setter:
+            #             return (setter, ir)
 
         return None
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1332,14 +1332,14 @@ class FuncDecl:
                  class_name: Optional[str],
                  module_name: str,
                  sig: FuncSignature,
-                 kind: int = FUNC_NORMAL,
-                 is_prop_setter: bool = False) -> None:
+                 kind: int = FUNC_NORMAL) -> None:
         self.name = name
         self.class_name = class_name
         self.module_name = module_name
         self.sig = sig
         self.kind = kind
-        self.is_prop_setter = is_prop_setter
+        self.is_prop_setter = False
+        self.is_prop_getter = False
         if class_name is None:
             self.bound_sig = None  # type: Optional[FuncSignature]
         else:
@@ -1581,16 +1581,6 @@ class ClassIR:
         for ir in self.mro:
             if name in ir.methods:
                 return ir.methods[name], ir
-
-            # if name in ir.properties:
-            #     return ir.properties[name][0], ir
-
-            # if name.startswith(PROPSET_PREFIX):
-            #     prop_name = name.split(PROPSET_PREFIX)[1]
-            #     if prop_name in ir.properties:
-            #         setter = ir.properties[prop_name][1]
-            #         if setter:
-            #             return (setter, ir)
 
         return None
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2861,15 +2861,16 @@ class A:
     def foo(self, val : Foo) -> None:
         self._foo = val
 
-a = A()
-print(a.x)
-a.x = 3
-print(a.x)
-print(a.foo.attr)
-a.foo.attr = "modified"
-print(a.foo.attr)
+def test():
+    a = A()
+    assert a.x == 0
+    a.x = 3
+    assert a.x == 3
+    assert a.foo.attr == "unmodified"
+    a.foo.attr = "modified"
+    assert a.foo.attr == "modified"
 
-#Overrides base property setters and getters
+# Overrides base property setters and getters
 class B(A):
     def __init__(self) -> None:
         self._x = 10
@@ -2919,71 +2920,52 @@ class F(D):
         self._x = val + 10
     
 # # Property setter and getter are subtypes of base property setters and getters
-# class G(A):
-#   def __init__(self) -> None:
-#       A.__init__(self)
+# # class G(A):
+# #   def __init__(self) -> None:
+# #       A.__init__(self)
 
-#   @property
-#   def y(self) -> int:
-#       return self._y
+# #   @property
+# #   def y(self) -> int:
+# #       return self._y
 
-#   @y.setter
-#   def y(self, val : object) -> None:
-#       self._y = val
+# #   @y.setter
+# #   def y(self, val : object) -> None:
+# #       self._y = val
 
 [file driver.py]
-from native import A, B, C, D, E, F
-
+from native import A, B, C, D, E, F, test
+# from native import A
+test()
 a = A()
-print(a.x)
-print(a._x)
+assert a.x == 0
+assert a._x == 0
 a.x = 1
-print(a.x)
-print(a._x)
+assert a.x == 1
+assert a._x == 1
 a._x = 0
-print(a.x)
-print(a._x)
+assert a.x == 0
+assert a._x == 0
 b = B()
-print(b.x)
-print(b._x)
+assert b.x == 11
+assert b._x == 10
 b.x = 11
-print(b.x)
+assert b.x == 13
 b._x = 11
-print(b.x)
+assert b.x == 12
 c = C()
-print(c.x)
+assert c.x == 0
 c.x = 1000
-print(c.x)
+assert c.x == 1000
 e = E()
-print(e.x)
+assert e.x == 0
 e.x = 1000
-print(e.x)
+assert e.x == 1000
 f = F()
-print(f.x)
+assert f.x == 20
 f.x = 30
-print(f.x)
+assert f.x == 50
 
 [out]
-0
-3
-unmodified
-modified
-0
-0
-1
-1
-0
-0
-11
-10
-13
-12
-0
-1000
-0
-1000
-20
-50
 
 [case testDunders]
 from typing import Any

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2864,11 +2864,32 @@ class A:
 def test():
     a = A()
     assert a.x == 0
-    a.x = 3
-    assert a.x == 3
-    assert a.foo.attr == "unmodified"
-    a.foo.attr = "modified"
-    assert a.foo.attr == "modified"
+    assert a._x == 0
+    a.x = 1
+    assert a.x == 1
+    assert a._x == 1
+    a._x = 0
+    assert a.x == 0
+    assert a._x == 0
+    b = B()
+    assert b.x == 11
+    assert b._x == 10
+    b.x = 11
+    assert b.x == 13
+    b._x = 11
+    assert b.x == 12
+    c = C()
+    assert c.x == 0
+    c.x = 1000
+    assert c.x == 1000
+    e = E()
+    assert e.x == 0
+    e.x = 1000
+    assert e.x == 1000
+    f = F()
+    assert f.x == 20
+    f.x = 30
+    assert f.x == 50
 
 # Overrides base property setters and getters
 class B(A):
@@ -2934,7 +2955,6 @@ class F(D):
 
 [file driver.py]
 from native import A, B, C, D, E, F, test
-# from native import A
 test()
 a = A()
 assert a.x == 0

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2832,6 +2832,159 @@ Represents a sequence of values. Updates itself by next, which is a new value.
 3
 3
 
+[case testPropertySetters]
+
+from mypy_extensions import trait
+
+class Foo():
+    def __init__(self) -> None:
+        self.attr = "unmodified"
+
+class A:
+    def __init__(self) -> None:
+        self._x = 0
+        self._foo = Foo()
+
+    @property
+    def x(self) -> int:
+        return self._x
+
+    @x.setter
+    def x(self, val : int) -> None:
+        self._x = val
+
+    @property
+    def foo(self) -> Foo:
+        return self._foo
+
+    @foo.setter
+    def foo(self, val : Foo) -> None:
+        self._foo = val
+
+a = A()
+print(a.x)
+a.x = 3
+print(a.x)
+print(a.foo.attr)
+a.foo.attr = "modified"
+print(a.foo.attr)
+
+#Overrides base property setters and getters
+class B(A):
+    def __init__(self) -> None:
+        self._x = 10
+
+    @property
+    def x(self) -> int:
+        return self._x + 1
+
+    @x.setter
+    def x(self, val : int) -> None:
+        self._x = val + 1
+
+#Inerits base property setters and getters
+class C(A):
+    def __init__(self) -> None:
+        A.__init__(self)
+
+@trait
+class D():
+    def __init__(self) -> None:
+        self._x = 0
+
+    @property
+    def x(self) -> int:
+        return self._x
+
+    @x.setter
+    def x(self, val : int) -> None:
+        self._x = val
+
+#Inherits trait property setters and getters
+class E(D):
+    def __init__(self) -> None:
+        D.__init__(self)
+
+#Overrides trait property setters and getters
+class F(D):
+    def __init__(self) -> None:
+        self._x = 10
+
+    @property
+    def x(self) -> int:
+        return self._x + 10
+
+    @x.setter
+    def x(self, val : int) -> None:
+        self._x = val + 10
+    
+# # Property setter and getter are subtypes of base property setters and getters
+# class G(A):
+#   def __init__(self) -> None:
+#       A.__init__(self)
+
+#   @property
+#   def y(self) -> int:
+#       return self._y
+
+#   @y.setter
+#   def y(self, val : object) -> None:
+#       self._y = val
+
+[file driver.py]
+from native import A, B, C, D, E, F
+
+a = A()
+print(a.x)
+print(a._x)
+a.x = 1
+print(a.x)
+print(a._x)
+a._x = 0
+print(a.x)
+print(a._x)
+b = B()
+print(b.x)
+print(b._x)
+b.x = 11
+print(b.x)
+b._x = 11
+print(b.x)
+c = C()
+print(c.x)
+c.x = 1000
+print(c.x)
+e = E()
+print(e.x)
+e.x = 1000
+print(e.x)
+f = F()
+print(f.x)
+f.x = 30
+print(f.x)
+
+[out]
+0
+3
+unmodified
+modified
+0
+0
+1
+1
+0
+0
+11
+10
+13
+12
+0
+1000
+0
+1000
+20
+50
+
 [case testDunders]
 from typing import Any
 class Item:


### PR DESCRIPTION
This pull request adds mypyc support for property setters. However, with these additions, mypyc still does not support contravariant subtyping of the input type for overriden property setters (which should be supported).

Resolves #532 