### PR TITLE
Support *args in lhs

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -335,8 +335,10 @@ class AssignmentTargetAttr(AssignmentTarget):
 class AssignmentTargetTuple(AssignmentTarget):
     """x, ..., y as assignment target"""
 
-    def __init__(self, items: List[AssignmentTarget]) -> None:
+    def __init__(self, items: List[AssignmentTarget],
+                 starred: Optional[AssignmentTarget] = None) -> None:
         self.items = items
+        self.starred = starred
         # The shouldn't be relevant, but provide it just in case.
         self.type = object_rprimitive
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -336,9 +336,9 @@ class AssignmentTargetTuple(AssignmentTarget):
     """x, ..., y as assignment target"""
 
     def __init__(self, items: List[AssignmentTarget],
-                 starred: Optional[AssignmentTarget] = None) -> None:
+                 star_idx: Optional[int] = None) -> None:
         self.items = items
-        self.starred = starred
+        self.star_idx = star_idx
         # The shouldn't be relevant, but provide it just in case.
         self.type = object_rprimitive
 

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -19,7 +19,7 @@ name_ref_op('builtins.list',
             emit=simple_emit('{dest} = (PyObject *)&PyList_Type;'),
             is_borrowed=True)
 
-func_op(
+to_list = func_op(
     name='builtins.list',
     arg_types=[object_rprimitive],
     result_type=list_rprimitive,
@@ -96,14 +96,14 @@ list_extend_op = method_op(
     error_kind=ERR_MAGIC,
     emit=simple_emit('{dest} = _PyList_Extend((PyListObject *) {args[0]}, {args[1]});'))
 
-method_op(
+list_pop_last = method_op(
     name='pop',
     arg_types=[list_rprimitive],
     result_type=object_rprimitive,
     error_kind=ERR_MAGIC,
     emit=call_emit('CPyList_PopLast'))
 
-method_op(
+list_pop = method_op(
     name='pop',
     arg_types=[list_rprimitive, int_rprimitive],
     result_type=object_rprimitive,

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -170,5 +170,3 @@ d1 = {1: 2}
 
 async def aio(x: Any) -> Any:  # E: async functions are unimplemented
     await x  # E: await is unimplemented
-
-a, *b, c = [1, 2, 3, 4]  # E: Unpacking with * is unimplemented

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2353,6 +2353,9 @@ from native import f
 assert f([(5, 6)]) == 11
 
 [case testUnpack]
+
+from typing import List
+
 a, *b = [1, 2, 3, 4, 5]
 
 *c, d = [1, 2, 3, 4, 5]
@@ -2365,53 +2368,69 @@ m, *n, o = [1, 2, 3, 4, 5, 6]
 
 p, q, r, *s, t = [1,2,3,4,5,6,7,8,9,10]
 
-def tests():
-    assert a == 1
-    assert b == [2,3,4,5]
-    assert e == 1
-    assert f == [2]
-    assert p == 1
-    assert q == 2
-    assert r == 3
-    assert s == [4,5,6,7,8,9]
-    assert t == 10
+tup = (1,2,3)
+y, *z = tup
+
+def unpack1(l : List[int]) -> None:
+    *v1, v2, v3 = l
+
+def unpack2(l : List[int]) -> None:
+    v1, *v2, v3 = l
+
+def unpack3(l : List[int]) -> None:
+    v1, v2, *v3 = l
+
+[file testutil.py]
+# TODO: This should go into some general mypyc test support lib (along
+# with other things)
+from contextlib import contextmanager
+from typing import Iterator
+
+@contextmanager
+def assertRaises(typ: type, msg: str = '') -> Iterator[None]:
+    try:
+        yield
+    except Exception as e:
+        assert isinstance(e, typ), "{} is not a {}".format(e, typ.__name__)
+        assert msg in str(e), 'Message "{}" does not match "{}"'.format(e, msg)
+    else:
+        assert False, "Expected {} but got no exception".format(typ.__name__)
 
 [file driver.py]
-from native import a, b, tests
-
-tests()
+from native import a, b, c, d, e, f, j, k, l, m, n, o, p, q, r, s, t, y, z
+from native import unpack1, unpack2, unpack3
+from testutil import assertRaises
 
 assert a == 1
 assert b == [2,3,4,5]
-
-from native import c, d
-
 assert c == [1,2,3,4]
 assert d == 5
-
-from native import e, f
-
 assert e == 1
 assert f == [2]
-
-from native import j, k, l
-
 assert j == 1
 assert k == [2]
 assert l == 3
-
-from native import m, n, o
-
 assert m == 1
 assert n == [2,3,4,5]
 assert o == 6
-
-from native import p, q, r, s, t
 assert p == 1
 assert q == 2
 assert r == 3
 assert s == [4,5,6,7,8,9]
 assert t == 10
+assert y == 1
+assert z == [2,3]
+
+with assertRaises(ValueError, "not enough values to unpack"):
+    unpack1([1])
+
+with assertRaises(ValueError, "not enough values to unpack"):
+    unpack2([1])
+
+with assertRaises(ValueError, "not enough values to unpack"):
+    unpack3([1])
+
+[out]
 
 [case testModuleTopLevel]
 x = 1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2352,6 +2352,67 @@ def f(x: List[Tuple[int, int]]) -> int:
 from native import f
 assert f([(5, 6)]) == 11
 
+[case testUnpack]
+a, *b = [1, 2, 3, 4, 5]
+
+*c, d = [1, 2, 3, 4, 5]
+
+e, *f = [1,2]
+
+j, *k, l = [1, 2, 3]
+
+m, *n, o = [1, 2, 3, 4, 5, 6]
+
+p, q, r, *s, t = [1,2,3,4,5,6,7,8,9,10]
+
+def tests():
+    assert a == 1
+    assert b == [2,3,4,5]
+    assert e == 1
+    assert f == [2]
+    assert p == 1
+    assert q == 2
+    assert r == 3
+    assert s == [4,5,6,7,8,9]
+    assert t == 10
+
+[file driver.py]
+from native import a, b, tests
+
+tests()
+
+assert a == 1
+assert b == [2,3,4,5]
+
+from native import c, d
+
+assert c == [1,2,3,4]
+assert d == 5
+
+from native import e, f
+
+assert e == 1
+assert f == [2]
+
+from native import j, k, l
+
+assert j == 1
+assert k == [2]
+assert l == 3
+
+from native import m, n, o
+
+assert m == 1
+assert n == [2,3,4,5]
+assert o == 6
+
+from native import p, q, r, s, t
+assert p == 1
+assert q == 2
+assert r == 3
+assert s == [4,5,6,7,8,9]
+assert t == 10
+
 [case testModuleTopLevel]
 x = 1
 print(x)


### PR DESCRIPTION
This pull request adds support for *args in the left hand side of an assignment
(ex: a, *b, c = [1,2,3,4])
(ex: a, *b = [1,2,3])

Resolves #594 