### PR TITLE
Add -Wno-unknown-warning-option to cflag list

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -318,7 +318,7 @@ def mypycify(paths: List[str],
         cflags += [
             '-O{}'.format(opt_level), '-Werror', '-Wno-unused-function', '-Wno-unused-label',
             '-Wno-unreachable-code', '-Wno-unused-variable', '-Wno-trigraphs',
-            '-Wno-unused-command-line-argument'
+            '-Wno-unused-command-line-argument', '-Wno-unknown-warning-option',
         ]
         if 'gcc' in compiler.compiler[0]:
             # This flag is needed for gcc but does not exist on clang.


### PR DESCRIPTION
I added the -Wno-unknown-warning-option to the compiler flag list in build.py. Without this flag, I get the following error message running mypyc on my MacBook Pro (with Mojave).

`error: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Werror,-Wunknown-warning-option]`