### PR TITLE
Make tuple structs identified/named based on runtime representation

### DIFF
--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -63,6 +63,28 @@ class RType:
         return hash(self.name)
 
 
+class RTypeVisitor(Generic[T]):
+    @abstractmethod
+    def visit_rprimitive(self, typ: 'RPrimitive') -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_rinstance(self, typ: 'RInstance') -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_runion(self, typ: 'RUnion') -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_rtuple(self, typ: 'RTuple') -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_rvoid(self, typ: 'RVoid') -> T:
+        raise NotImplementedError
+
+
 class RVoid(RType):
     """void"""
 
@@ -180,6 +202,31 @@ def is_tuple_rprimitive(rtype: RType) -> bool:
     return isinstance(rtype, RPrimitive) and rtype.name == 'builtins.tuple'
 
 
+class TupleNameVisitor(RTypeVisitor[str]):
+    """Produce a tuple name based on the concrete representations of types."""
+
+    def visit_rinstance(self, t: 'RInstance') -> str:
+        return "O"
+
+    def visit_runion(self, t: 'RUnion') -> str:
+        return "O"
+
+    def visit_rprimitive(self, t: 'RPrimitive') -> str:
+        if t._ctype == 'CPyTagged':
+            return 'I'
+        elif t._ctype == 'char':
+            return 'C'
+        assert not t.is_unboxed, "{} unexpected unboxed type".format(t)
+        return 'O'
+
+    def visit_rtuple(self, t: 'RTuple') -> str:
+        parts = [elem.accept(self) for elem in t.types]
+        return 'T{}{}'.format(len(parts), ''.join(parts))
+
+    def visit_rvoid(self, t: 'RVoid') -> str:
+        assert False, "rvoid in tuple?"
+
+
 class RTuple(RType):
     """Fixed-length unboxed tuple (represented as a C struct)."""
 
@@ -188,9 +235,13 @@ class RTuple(RType):
     def __init__(self, types: List[RType]) -> None:
         self.name = 'tuple'
         self.types = tuple(types)
-        # Emitter has logic for generating a C type for RTuple.
-        self._ctype = ''
         self.is_refcounted = any(t.is_refcounted for t in self.types)
+        # Generate a unique id which is used in naming corresponding C identifiers.
+        # This is necessary since C does not have anonymous structural type equivalence
+        # in the same way python can just assign a Tuple[int, bool] to a Tuple[int, bool].
+        self.unique_id = self.accept(TupleNameVisitor())
+        # Nominally the max c length is 31 chars, but I'm not honestly worried about this.
+        self._ctype = 'tuple_' + self.unique_id
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rtuple(self)
@@ -1771,28 +1822,6 @@ def all_concrete_classes(class_ir: ClassIR) -> List[ClassIR]:
     if not (class_ir.is_abstract or class_ir.is_trait):
         concrete.append(class_ir)
     return concrete
-
-
-class RTypeVisitor(Generic[T]):
-    @abstractmethod
-    def visit_rprimitive(self, typ: RPrimitive) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_rinstance(self, typ: RInstance) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_runion(self, typ: RUnion) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_rtuple(self, typ: RTuple) -> T:
-        raise NotImplementedError
-
-    @abstractmethod
-    def visit_rvoid(self, typ: RVoid) -> T:
-        raise NotImplementedError
 
 
 # Import various modules that set up global state.

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -241,7 +241,8 @@ class RTuple(RType):
         # in the same way python can just assign a Tuple[int, bool] to a Tuple[int, bool].
         self.unique_id = self.accept(TupleNameVisitor())
         # Nominally the max c length is 31 chars, but I'm not honestly worried about this.
-        self._ctype = 'tuple_' + self.unique_id
+        self.struct_name = 'tuple_{}'.format(self.unique_id)
+        self._ctype = 'struct {}'.format(self.struct_name)
 
     def accept(self, visitor: 'RTypeVisitor[T]') -> T:
         return visitor.visit_rtuple(self)

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -49,10 +49,10 @@ class RTSubtypeVisitor(RTypeVisitor[bool]):
         return left is self.right
 
     def visit_rtuple(self, left: RTuple) -> bool:
-        # We might want to implement runtime subtyping for tuples. The
-        # obstacle is that we generate different (but equivalent)
-        # tuple structs.
-        return is_same_type(left, self.right)
+        if isinstance(self.right, RTuple):
+            return len(self.right.types) == len(left.types) and all(
+                is_runtime_subtype(t1, t2) for t1, t2 in zip(left.types, self.right.types))
+        return False
 
     def visit_rvoid(self, left: RVoid) -> bool:
         return isinstance(self.right, RVoid)

--- a/mypyc/test/test_tuplename.py
+++ b/mypyc/test/test_tuplename.py
@@ -1,0 +1,22 @@
+import unittest
+
+from mypyc.ops import (
+    RTuple, object_rprimitive, int_rprimitive, bool_rprimitive, list_rprimitive,
+    RInstance, RUnion,
+    ClassIR,
+)
+
+class TestTupleNames(unittest.TestCase):
+    def setUp(self) -> None:
+        self.inst_a = RInstance(ClassIR('A', '__main__'))
+        self.inst_b = RInstance(ClassIR('B', '__main__'))
+
+    def test_names(self) -> None:
+        assert RTuple([int_rprimitive, int_rprimitive]).unique_id == "T2II"
+        assert RTuple([list_rprimitive, object_rprimitive, self.inst_a]).unique_id == "T3OOO"
+        assert RTuple([list_rprimitive, object_rprimitive, self.inst_b]).unique_id == "T3OOO"
+        assert RTuple([]).unique_id == "T0"
+        assert RTuple([RTuple([]),
+                       RTuple([int_rprimitive, int_rprimitive])]).unique_id == "T2T0T2II"
+        assert RTuple([bool_rprimitive,
+                       RUnion([bool_rprimitive, int_rprimitive])]).unique_id == "T2CO"

--- a/mypyc/test/test_tuplename.py
+++ b/mypyc/test/test_tuplename.py
@@ -6,6 +6,7 @@ from mypyc.ops import (
     ClassIR,
 )
 
+
 class TestTupleNames(unittest.TestCase):
     def setUp(self) -> None:
         self.inst_a = RInstance(ClassIR('A', '__main__'))


### PR DESCRIPTION
Give them names based on the runtime types the contain.

This means that tuples whose component types have the same runtime
representation will also have the same runtime representation, so we
can do runtime subtyping on tuples.

This is also in preparation for separate compilation where it will
form the basis of standard naming of tuples between modules.  (And
will be combined with some preprocessor stuff to ensure that it gets
defined once).