### PR TITLE
Refactored mypyc for self compilation

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,27 +1,31 @@
-PREFIX = 'CPyPy_'  # Python wrappers
-NATIVE_PREFIX = 'CPyDef_'  # Native functions etc.
-DUNDER_PREFIX = 'CPyDunder_'  # Wrappers for exposing dunder methods to the API
-REG_PREFIX = 'cpy_r_'  # Registers
-STATIC_PREFIX = 'CPyStatic_'  # Static variables (for literals etc.)
-TYPE_PREFIX = 'CPyType_'  # Type object struct
-ATTR_PREFIX = '_'  # Attributes
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
-ENV_ATTR_NAME = '__mypyc_env__'
-NEXT_LABEL_ATTR_NAME = '__mypyc_next_label__'
-TEMP_ATTR_NAME = '__mypyc_temp__'
-LAMBDA_NAME = '__mypyc_lambda__'
-PROPSET_PREFIX = '__mypyc_setter__'
-SELF_NAME = '__mypyc_self__'
-INT_PREFIX = '__tmp_literal_int_'
+PREFIX = 'CPyPy_'  # type: Final # Python wrappers
+NATIVE_PREFIX = 'CPyDef_'  # type: Final # Native functions etc.
+DUNDER_PREFIX = 'CPyDunder_'  # type: Final # Wrappers for exposing dunder methods to the API
+REG_PREFIX = 'cpy_r_'  # type: Final # Registers
+STATIC_PREFIX = 'CPyStatic_'  # type: Final # Static variables (for literals etc.)
+TYPE_PREFIX = 'CPyType_'  # type: Final # Type object struct
+ATTR_PREFIX = '_'  # type: Final # Attributes
+
+ENV_ATTR_NAME = '__mypyc_env__'  # type: Final
+NEXT_LABEL_ATTR_NAME = '__mypyc_next_label__'  # type: Final
+TEMP_ATTR_NAME = '__mypyc_temp__'  # type: Final
+LAMBDA_NAME = '__mypyc_lambda__'  # type: Final
+PROPSET_PREFIX = '__mypyc_setter__'  # type: Final
+SELF_NAME = '__mypyc_self__'  # type: Final
+INT_PREFIX = '__tmp_literal_int_'  # type: Final
 
 # Max short int we accept as a literal is based on 32-bit platforms,
 # so that we can just always emit the same code.
-MAX_LITERAL_SHORT_INT = (1 << 30) - 1
+MAX_LITERAL_SHORT_INT = (1 << 30) - 1  # type: Final
 
-TOP_LEVEL_NAME = '__top_level__'  # Special function representing module top level
+TOP_LEVEL_NAME = '__top_level__'  # type: Final # Special function representing module top level
 
 # Maximal number of subclasses for a class to trigger fast path in isinstance() checks.
-FAST_ISINSTANCE_MAX_SUBCLASSES = 2
+FAST_ISINSTANCE_MAX_SUBCLASSES = 2  # type: Final
 
 
 def decorator_helper_name(func_name: str) -> str:

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -14,6 +14,9 @@ from mypyc.ops import (
 )
 from mypyc.namegen import NameGenerator
 
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 # Whether to insert debug asserts for all error handling, to quickly
 # catch errors propagating without exceptions set.
@@ -258,7 +261,7 @@ class FunctionEmitterVisitor(OpVisitor[None], EmitterInterface):
     PREFIX_MAP = {
         NAMESPACE_STATIC: STATIC_PREFIX,
         NAMESPACE_TYPE: TYPE_PREFIX,
-    }
+    }  # type: Final
 
     def visit_load_static(self, op: LoadStatic) -> None:
         dest = self.reg(op)

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -14,6 +14,10 @@ from mypy.nodes import ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED, ARG_STAR, ARG
 
 from typing import List, Optional
 
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
+
 
 def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
     return 'PyObject *{prefix}{name}(PyObject *self, PyObject *args, PyObject *kw)'.format(
@@ -198,7 +202,7 @@ def generate_bool_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
 
 
 def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
-                          optional_args: List[RuntimeArg] = [],
+                          optional_args: Optional[List[RuntimeArg]] = None,
                           arg_names: Optional[List[str]] = None,
                           cleanups: Optional[List[str]] = None) -> None:
     """Generates the core part of a wrapper function for a native function.
@@ -206,6 +210,8 @@ def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
     It converts the PyObject *s to the necessary types, checking and unboxing if necessary,
     makes the call, then boxes the result if necessary and returns it.
     """
+
+    optional_args = optional_args or []
     cleanups = cleanups or []
     error_code = 'return NULL;' if not cleanups else 'goto fail;'
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -775,6 +775,42 @@ class NonlocalControl:
     def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None: pass
 
 
+class LoopNonlocalControl(NonlocalControl):
+    def __init__(self, outer: NonlocalControl,
+                 continue_block: BasicBlock, break_block: BasicBlock) -> None:
+        self.outer = outer
+        self.continue_block = continue_block
+        self.break_block = break_block
+
+    def gen_break(self, builder: 'IRBuilder', line: int) -> None:
+        builder.add(Goto(self.break_block))
+
+    def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
+        builder.add(Goto(self.continue_block))
+
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
+        self.outer.gen_return(builder, value, line)
+
+
+class TryFinallyNonlocalControl(NonlocalControl):
+    def __init__(self, target: BasicBlock) -> None:
+        self.target = target
+        self.ret_reg = None  # type: Optional[Register]
+
+    def gen_break(self, builder: 'IRBuilder', line: int) -> None:
+        builder.error("break inside try/finally block is unimplemented", line)
+
+    def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
+        builder.error("continue inside try/finally block is unimplemented", line)
+
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
+        if self.ret_reg is None:
+            self.ret_reg = builder.alloc_temp(builder.ret_types[-1])
+
+        builder.add(Assign(self.ret_reg, value))
+        builder.add(Goto(self.target))
+
+
 class BaseNonlocalControl(NonlocalControl):
     def gen_break(self, builder: 'IRBuilder', line: int) -> None:
         assert False, "break outside of loop"
@@ -784,6 +820,24 @@ class BaseNonlocalControl(NonlocalControl):
 
     def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
         builder.add(Return(value))
+
+
+class GeneratorNonlocalControl(BaseNonlocalControl):
+    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
+        # Assign an invalid next label number so that the next time __next__ is called, we jump to
+        # the case in which StopIteration is raised.
+        builder.assign(builder.fn_info.generator_class.next_label_target,
+                       builder.add(LoadInt(-1)),
+                       line)
+        # Raise a StopIteration containing a field for the value that should be returned. Before
+        # doing so, create a new block without an error handler set so that the implicitly thrown
+        # StopIteration isn't caught by except blocks inside of the generator function.
+        builder.error_handlers.append(None)
+        builder.goto_new_block()
+        builder.add(RaiseStandardError(RaiseStandardError.STOP_ITERATION, value,
+                                       line))
+        builder.add(Unreachable())
+        builder.error_handlers.pop()
 
 
 class CleanupNonlocalControl(NonlocalControl):
@@ -807,22 +861,46 @@ class CleanupNonlocalControl(NonlocalControl):
         self.outer.gen_return(builder, value, line)
 
 
-class GeneratorNonlocalControl(BaseNonlocalControl):
-    def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
-        # Assign an invalid next label number so that the next time __next__ is called, we jump to
-        # the case in which StopIteration is raised.
-        builder.assign(builder.fn_info.generator_class.next_label_target,
-                       builder.add(LoadInt(-1)),
-                       line)
-        # Raise a StopIteration containing a field for the value that should be returned. Before
-        # doing so, create a new block without an error handler set so that the implicitly thrown
-        # StopIteration isn't caught by except blocks inside of the generator function.
-        builder.error_handlers.append(None)
-        builder.goto_new_block()
-        builder.add(RaiseStandardError(RaiseStandardError.STOP_ITERATION, value,
-                                       line))
-        builder.add(Unreachable())
-        builder.error_handlers.pop()
+class ExceptNonlocalControl(CleanupNonlocalControl):
+    """Nonlocal control for except blocks.
+
+    Just makes sure that sys.exc_info always gets restored when we leave.
+    This is super annoying.
+    """
+    def __init__(self, outer: NonlocalControl, saved: Value) -> None:
+        super().__init__(outer)
+        self.saved = saved
+
+    def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
+        builder.primitive_op(restore_exc_info_op, [self.saved], line)
+
+
+class FinallyNonlocalControl(CleanupNonlocalControl):
+    """Nonlocal control for finally blocks.
+
+    Just makes sure that sys.exc_info always gets restored when we
+    leave and the return register is decrefed if it isn't null.
+    """
+    def __init__(self, outer: NonlocalControl, ret_reg: Optional[Value], saved: Value) -> None:
+        super().__init__(outer)
+        self.ret_reg = ret_reg
+        self.saved = saved
+
+    def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
+        # Do an error branch on the return value register, which
+        # may be undefined. This will allow it to be properly
+        # decrefed if it is not null. This is kind of a hack.
+        if self.ret_reg:
+            target = BasicBlock()
+            builder.add(Branch(self.ret_reg, target, target, Branch.IS_ERROR))
+            builder.activate_block(target)
+
+        # Restore the old exc_info
+        target, cleanup = BasicBlock(), BasicBlock()
+        builder.add(Branch(self.saved, target, cleanup, Branch.IS_ERROR))
+        builder.activate_block(cleanup)
+        builder.primitive_op(restore_exc_info_op, [self.saved], line)
+        builder.goto_and_activate(target)
 
 
 class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
@@ -1864,25 +1942,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.goto(next)
         self.activate_block(next)
 
-    class LoopNonlocalControl(NonlocalControl):
-        def __init__(self, outer: NonlocalControl,
-                     continue_block: BasicBlock, break_block: BasicBlock) -> None:
-            self.outer = outer
-            self.continue_block = continue_block
-            self.break_block = break_block
-
-        def gen_break(self, builder: 'IRBuilder', line: int) -> None:
-            builder.add(Goto(self.break_block))
-
-        def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
-            builder.add(Goto(self.continue_block))
-
-        def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
-            self.outer.gen_return(builder, value, line)
-
     def push_loop_stack(self, continue_block: BasicBlock, break_block: BasicBlock) -> None:
         self.nonlocal_control.append(
-            IRBuilder.LoopNonlocalControl(self.nonlocal_control[-1], continue_block, break_block))
+            LoopNonlocalControl(self.nonlocal_control[-1], continue_block, break_block))
 
     def pop_loop_stack(self) -> None:
         self.nonlocal_control.pop()
@@ -3072,19 +3134,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.primitive_op(raise_exception_op, [exc], s.line)
         self.add(Unreachable())
 
-    class ExceptNonlocalControl(CleanupNonlocalControl):
-        """Nonlocal control for except blocks.
-
-        Just makes sure that sys.exc_info always gets restored when we leave.
-        This is super annoying.
-        """
-        def __init__(self, outer: NonlocalControl, saved: Value) -> None:
-            super().__init__(outer)
-            self.saved = saved
-
-        def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
-            builder.primitive_op(restore_exc_info_op, [self.saved], line)
-
     def visit_try_except(self,
                          body: GenFunc,
                          handlers: Sequence[
@@ -3119,7 +3168,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         old_exc = self.primitive_op(error_catch_op, [], line)
         # Compile the except blocks with the nonlocal control flow overridden to clear exc_info
         self.nonlocal_control.append(
-            IRBuilder.ExceptNonlocalControl(self.nonlocal_control[-1], old_exc))
+            ExceptNonlocalControl(self.nonlocal_control[-1], old_exc))
 
         # Process the bodies
         for type, var, handler_body in handlers:
@@ -3181,55 +3230,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         else_body = (lambda: self.accept(t.else_body)) if t.else_body else None
         self.visit_try_except(body, handlers, else_body, t.line)
 
-    class TryFinallyNonlocalControl(NonlocalControl):
-        def __init__(self, target: BasicBlock) -> None:
-            self.target = target
-            self.ret_reg = None  # type: Optional[Register]
-
-        def gen_break(self, builder: 'IRBuilder', line: int) -> None:
-            builder.error("break inside try/finally block is unimplemented", line)
-
-        def gen_continue(self, builder: 'IRBuilder', line: int) -> None:
-            builder.error("continue inside try/finally block is unimplemented", line)
-
-        def gen_return(self, builder: 'IRBuilder', value: Value, line: int) -> None:
-            if self.ret_reg is None:
-                self.ret_reg = builder.alloc_temp(builder.ret_types[-1])
-
-            builder.add(Assign(self.ret_reg, value))
-            builder.add(Goto(self.target))
-
-    class FinallyNonlocalControl(CleanupNonlocalControl):
-        """Nonlocal control for finally blocks.
-
-        Just makes sure that sys.exc_info always gets restored when we
-        leave and the return register is decrefed if it isn't null.
-        """
-        def __init__(self, outer: NonlocalControl, ret_reg: Optional[Value], saved: Value) -> None:
-            super().__init__(outer)
-            self.ret_reg = ret_reg
-            self.saved = saved
-
-        def gen_cleanup(self, builder: 'IRBuilder', line: int) -> None:
-            # Do an error branch on the return value register, which
-            # may be undefined. This will allow it to be properly
-            # decrefed if it is not null. This is kind of a hack.
-            if self.ret_reg:
-                target = BasicBlock()
-                builder.add(Branch(self.ret_reg, target, target, Branch.IS_ERROR))
-                builder.activate_block(target)
-
-            # Restore the old exc_info
-            target, cleanup = BasicBlock(), BasicBlock()
-            builder.add(Branch(self.saved, target, cleanup, Branch.IS_ERROR))
-            builder.activate_block(cleanup)
-            builder.primitive_op(restore_exc_info_op, [self.saved], line)
-            builder.goto_and_activate(target)
-
     def try_finally_try(self, err_handler: BasicBlock, return_entry: BasicBlock,
                         main_entry: BasicBlock, try_body: GenFunc) -> Optional[Register]:
         # Compile the try block with an error handler
-        control = IRBuilder.TryFinallyNonlocalControl(return_entry)
+        control = TryFinallyNonlocalControl(return_entry)
         self.error_handlers.append(err_handler)
 
         self.nonlocal_control.append(control)
@@ -3273,7 +3277,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         cleanup_block = BasicBlock()
         # Compile the finally block with the nonlocal control flow overridden to restore exc_info
         self.error_handlers.append(cleanup_block)
-        finally_control = IRBuilder.FinallyNonlocalControl(
+        finally_control = FinallyNonlocalControl(
             self.nonlocal_control[-1], ret_reg, old_exc)
         self.nonlocal_control.append(finally_control)
         self.activate_block(finally_block)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -22,8 +22,13 @@ from mypyc.common import PROPSET_PREFIX
 
 from mypy.nodes import Block, SymbolNode, Var, FuncDef, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
+from mypy_extensions import trait
+
 from mypyc.namegen import NameGenerator
 
+MYPY = False
+if MYPY:
+    from typing_extensions import Final
 
 T = TypeVar('T')
 
@@ -74,7 +79,7 @@ class RVoid(RType):
         return visitor.visit_rvoid(self)
 
 
-void_rtype = RVoid()
+void_rtype = RVoid()  # type: Final
 
 
 class RPrimitive(RType):
@@ -109,31 +114,36 @@ class RPrimitive(RType):
 
 
 # Used to represent arbitrary objects and dynamically typed values
-object_rprimitive = RPrimitive('builtins.object', is_unboxed=False, is_refcounted=True)
+object_rprimitive = RPrimitive('builtins.object', is_unboxed=False,
+                               is_refcounted=True)  # type: Final
 
-int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True, ctype='CPyTagged')
+int_rprimitive = RPrimitive('builtins.int', is_unboxed=True, is_refcounted=True,
+                            ctype='CPyTagged')  # type: Final
 
 short_int_rprimitive = RPrimitive('short_int', is_unboxed=True, is_refcounted=False,
-                                  ctype='CPyTagged')
+                                  ctype='CPyTagged')  # type: Final
 
-float_rprimitive = RPrimitive('builtins.float', is_unboxed=False, is_refcounted=True)
+float_rprimitive = RPrimitive('builtins.float', is_unboxed=False,
+                              is_refcounted=True)  # type: Final
 
-bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False, ctype='char')
+bool_rprimitive = RPrimitive('builtins.bool', is_unboxed=True, is_refcounted=False,
+                             ctype='char')  # type: Final
 
 none_rprimitive = RPrimitive('builtins.None', is_unboxed=True, is_refcounted=False,
-                             ctype='char')
+                             ctype='char')  # type: Final
 
-list_rprimitive = RPrimitive('builtins.list', is_unboxed=False, is_refcounted=True)
+list_rprimitive = RPrimitive('builtins.list', is_unboxed=False, is_refcounted=True)  # type: Final
 
-dict_rprimitive = RPrimitive('builtins.dict', is_unboxed=False, is_refcounted=True)
+dict_rprimitive = RPrimitive('builtins.dict', is_unboxed=False, is_refcounted=True)  # type: Final
 
-set_rprimitive = RPrimitive('builtins.set', is_unboxed=False, is_refcounted=True)
+set_rprimitive = RPrimitive('builtins.set', is_unboxed=False, is_refcounted=True)  # type: Final
 
 # At the C layer, str is refered to as unicode (PyUnicode)
-str_rprimitive = RPrimitive('builtins.str', is_unboxed=False, is_refcounted=True)
+str_rprimitive = RPrimitive('builtins.str', is_unboxed=False, is_refcounted=True)  # type: Final
 
 # Tuple of an arbitrary length (corresponds to Tuple[t, ...], with explicit '...')
-tuple_rprimitive = RPrimitive('builtins.tuple', is_unboxed=False, is_refcounted=True)
+tuple_rprimitive = RPrimitive('builtins.tuple', is_unboxed=False,
+                              is_refcounted=True)  # type: Final
 
 
 def is_int_rprimitive(rtype: RType) -> bool:
@@ -487,9 +497,12 @@ class BasicBlock:
         self.error_handler = None  # type: Optional[BasicBlock]
 
 
-ERR_NEVER = 0  # Never generates an exception
-ERR_MAGIC = 1  # Generates magic value (c_error_value) based on target RType on exception
-ERR_FALSE = 2  # Generates false (bool) on exception
+# Never generates an exception
+ERR_NEVER = 0  # type: Final
+# Generates magic value (c_error_value) based on target RType on exception
+ERR_MAGIC = 1  # type: Final
+# Generates false (bool) on exception
+ERR_FALSE = 2  # type: Final
 
 # Hack: using this line number for an op will supress it in tracebacks
 NO_TRACEBACK_LINE_NO = -10000
@@ -600,7 +613,7 @@ class Branch(ControlOp):
     op_names = {
         BOOL_EXPR: ('%r', 'bool'),
         IS_ERROR: ('is_error(%r)', ''),
-    }
+    }  # type: Final
 
     def __init__(self, left: Value, true_label: BasicBlock,
                  false_label: BasicBlock, op: int, line: int = -1, *, rare: bool = False) -> None:
@@ -823,7 +836,8 @@ class MethodCall(RegisterOp):
         return visitor.visit_method_call(self)
 
 
-class EmitterInterface:
+@trait
+class EmitterInterface():
     @abstractmethod
     def reg(self, name: Value) -> str:
         raise NotImplementedError
@@ -1049,10 +1063,8 @@ class SetAttr(RegisterOp):
         return visitor.visit_set_attr(self)
 
 
-# Default name space for statics, variables
-NAMESPACE_STATIC = 'static'
-# Static namespace for pointers to native type objects
-NAMESPACE_TYPE = 'type'
+NAMESPACE_STATIC = 'static'  # type: Final # Default name space for statics, variables
+NAMESPACE_TYPE = 'type'  # type: Final # Static namespace for pointers to native type objects
 
 
 class LoadStatic(RegisterOp):
@@ -1326,9 +1338,9 @@ class FuncSignature:
         return 'FuncSignature(args=%r, ret=%r)' % (self.args, self.ret_type)
 
 
-FUNC_NORMAL = 0
-FUNC_STATICMETHOD = 1
-FUNC_CLASSMETHOD = 2
+FUNC_NORMAL = 0  # type: Final
+FUNC_STATICMETHOD = 1  # type: Final
+FUNC_CLASSMETHOD = 2  # type: Final
 
 
 class FuncDecl:
@@ -1398,7 +1410,7 @@ class FuncIR:
         return '\n'.join(format_func(self))
 
 
-INVALID_FUNC_DEF = FuncDef('<INVALID_FUNC_DEF>', [], Block([]))
+INVALID_FUNC_DEF = FuncDef('<INVALID_FUNC_DEF>', [], Block([]))  # type: Final
 
 
 # Some notes on the vtable layout: Each concrete class has a vtable
@@ -1630,6 +1642,7 @@ class ModuleIR:
         self.final_names = final_names
 
 
+@trait
 class OpVisitor(Generic[T]):
     @abstractmethod
     def visit_goto(self, op: Goto) -> T:


### PR DESCRIPTION
This pull request refactors mypyc in the following ways:

-EmittterInterface and OpVisitor are now traits
-Eliminated use of nested classes in genops.py
-Annotated many final variables (by casing convention) in genops.py, ops.py, and common.py with type Final

These refactors are needed in order for mypyc to compile itself (and some may should have been done regardless).