### PR TITLE
Fix nested functions

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1677,14 +1677,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                                          reassign=False)
 
                     if self.fn_info.contains_nested and self.is_free_variable(symbol):
-                        if self.fn_info.is_nested:
-                            return self.add_var_to_env_class(symbol,
-                                                             self.node_type(lvalue),
-                                                             self.fn_info.callable_class,
-                                                             reassign=False)
-                        else:
-                            return self.add_var_to_env_class(symbol, self.node_type(lvalue),
-                                                             self.fn_info, reassign=False)
+                        env = self.fn_info.callable_class \
+                            if self.fn_info.is_nested \
+                            else self.fn_info  # type: Union[FuncInfo, ImplicitClass]
+
+                        return self.add_var_to_env_class(symbol,
+                                                         self.node_type(lvalue),
+                                                         env,
+                                                         reassign=False)
 
                     # Otherwise define a new local variable.
                     return self.environment.add_local_reg(symbol, self.node_type(lvalue))

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1677,8 +1677,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                                          reassign=False)
 
                     if self.fn_info.contains_nested and self.is_free_variable(symbol):
-                        return self.add_var_to_env_class(symbol, self.node_type(lvalue),
-                                                         self.fn_info, reassign=False)
+                        if self.fn_info.is_nested:
+                            return self.add_var_to_env_class(symbol,
+                                                             self.node_type(lvalue),
+                                                             self.fn_info.callable_class,
+                                                             reassign=False)
+                        else:
+                            return self.add_var_to_env_class(symbol, self.node_type(lvalue),
+                                                             self.fn_info, reassign=False)
 
                     # Otherwise define a new local variable.
                     return self.environment.add_local_reg(symbol, self.node_type(lvalue))

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1677,9 +1677,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                                          reassign=False)
 
                     if self.fn_info.contains_nested and self.is_free_variable(symbol):
-                        env = self.fn_info.callable_class \
-                            if self.fn_info.is_nested \
-                            else self.fn_info  # type: Union[FuncInfo, ImplicitClass]
+                        env = (self.fn_info.callable_class
+                               if self.fn_info.is_nested
+                               else self.fn_info)  # type: Union[FuncInfo, ImplicitClass]
 
                         return self.add_var_to_env_class(symbol,
                                                          self.node_type(lvalue),

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2133,6 +2133,16 @@ def first() -> Callable[[], Callable[[], str]]:
         return third
     return second
 
+def f1() -> int:
+        x = 1
+        def f2() -> int:
+                y = 2
+                def f3() -> int:
+                        z = 3
+                        return y
+                return f3()
+        return f2()
+
 def uno(num: float) -> Callable[[str], str]:
     def dos(s: str) -> str:
         return s + '!'
@@ -2169,7 +2179,7 @@ def third() -> str:
     return 'third: normal function'
 
 [file driver.py]
-from native import outer, inner, first, uno, eins, call_other_inner_func, second, third
+from native import outer, inner, first, uno, eins, call_other_inner_func, second, third, f1
 
 assert outer()() == None
 assert inner() == 'inner: normal function'
@@ -2179,6 +2189,7 @@ assert eins(4.0) == 'eins?'
 assert call_other_inner_func(5) == 21
 assert second() == 'second: normal function'
 assert third() == 'third: normal function'
+assert f1() == 2
 
 [case testOverloads]
 from typing import overload, Union, Tuple


### PR DESCRIPTION
Adds a case in genops.py to add a variable to a FuncInfo's callable_class's environment class register if that FuncInfo is nested and contains a nested function. This allows the added test case in run.test to compile and execute correctly (previously, mypyc would fail an assert because we tried accessing the environment class register of a nested function instead of it's callable class's environment class register).
