### PR TITLE
Fix nested name resolution

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 
-from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional, Iterable
+from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional, Iterable, Union
 
 from mypyc.ops import (
     Value, Register,
@@ -450,7 +450,7 @@ def run_analysis(blocks: List[BasicBlock],
         label = worklist.pop()
         workset.remove(label)
         if pred_map[label]:
-            new_before = None
+            new_before = None  # type: Union[Set[T], None]
             for pred in pred_map[label]:
                 if new_before is None:
                     new_before = set(after[pred])

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -934,8 +934,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # These variables are populated from the first-pass PreBuildVisitor.
         self.free_variables = pbv.free_variables
         self.prop_setters = pbv.prop_setters
-        self.encapsulating_fitems = pbv.encapsulating_funcs
-        self.nested_fitems = pbv.nested_funcs
+        self.encapsulating_funcs = pbv.encapsulating_funcs
+        self.nested_fitems = pbv.nested_funcs.keys()
         self.fdefs_to_decorators = pbv.funcs_to_decorators
 
         # This list operates similarly to a function call stack for nested functions. Whenever a
@@ -1466,12 +1466,12 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         func_reg = None  # type: Optional[Value]
 
-        # We treat lambdas as always being nested because we we always generate
+        # We treat lambdas as always being nested because we always generate
         # a class for lambdas, no matter where they are. (It would probably also
         # work to special case toplevel lambdas and generate a non-class function.)
         is_nested = fitem in self.nested_fitems or isinstance(fitem, LambdaExpr)
 
-        contains_nested = fitem in self.encapsulating_fitems
+        contains_nested = fitem in self.encapsulating_funcs.keys()
         is_decorated = fitem in self.fdefs_to_decorators
         self.enter(FuncInfo(fitem, name, class_name, self.gen_func_ns(),
                             is_nested, contains_nested, is_decorated))
@@ -1508,6 +1508,28 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.finalize_env_class()
 
         self.ret_types[-1] = sig.ret_type
+
+        # Add all variables and functions that are declared/defined within this
+        # function are referenced in functions nested within this one to this
+        # function's environment class so the nested functions can reference
+        # them, even if they are declared after the nested function's definition.
+        # Note that this is done before visiting the body of this function.
+
+        env_for_func = (self.fn_info.callable_class
+                        if self.fn_info.is_nested
+                        else self.fn_info)  # type: Union[FuncInfo, ImplicitClass]
+
+        if self.fn_info.fitem in self.free_variables:
+            for var in self.free_variables[self.fn_info.fitem]:
+                if isinstance(var, Var):
+                    rtype = self.type_to_rtype(var.type)
+                    self.add_var_to_env_class(var, rtype, env_for_func, reassign=False)
+
+        if self.fn_info.fitem in self.encapsulating_funcs:
+            for nested_fn in self.encapsulating_funcs[self.fn_info.fitem]:
+                if isinstance(nested_fn, FuncDef):
+                    self.add_var_to_env_class(nested_fn, object_rprimitive,
+                                              env_for_func, reassign=False)
 
         self.accept(fitem.body)
         self.maybe_add_implicit_return()
@@ -1752,16 +1774,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     if self.fn_info.is_generator:
                         return self.add_var_to_env_class(symbol, self.node_type(lvalue),
                                                          self.fn_info.generator_class,
-                                                         reassign=False)
-
-                    if self.fn_info.contains_nested and self.is_free_variable(symbol):
-                        env = (self.fn_info.callable_class
-                               if self.fn_info.is_nested
-                               else self.fn_info)  # type: Union[FuncInfo, ImplicitClass]
-
-                        return self.add_var_to_env_class(symbol,
-                                                         self.node_type(lvalue),
-                                                         env,
                                                          reassign=False)
 
                     # Otherwise define a new local variable.
@@ -2956,7 +2968,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             else:
                 accepted_items.append((False, self.accept(item)))
 
-        result = None
+        result = None  # type: Union[Value, None]
         initial_items = []
         for starred, value in accepted_items:
             if result is None and not starred and constructor_op.is_var_arg:
@@ -4113,7 +4125,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.box(self.accept(expr))
 
     def make_dict(self, key_value_pairs: Sequence[DictEntry], line: int) -> Value:
-        result = None
+        result = None  # type: Union[Value, None]
         initial_items = []  # type: List[Value]
         for key, value in key_value_pairs:
             if key is not None:
@@ -4413,7 +4425,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         function encapsulating the function being turned into a callable class.
         """
         fitem = fn_info.fitem
-
         func_reg = self.add(Call(fn_info.callable_class.ir.ctor, [], fitem.line))
 
         # Set the callable class' environment attribute to point at the environment class
@@ -4474,6 +4485,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def instantiate_env_class(self) -> Value:
         """Assigns an environment class to a register named after the given function definition."""
+        print("Here")
+        print(self.fn_info.env_class.ctor.name)
         curr_env_reg = self.add(Call(self.fn_info.env_class.ctor, [], self.fn_info.fitem.line))
 
         if self.fn_info.is_nested:
@@ -4850,13 +4863,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.add_var_to_env_class(fdef, object_rprimitive, self.fn_info.generator_class,
                                              reassign=False)
 
-        # If the given FuncDef is nested (i.e. if the parent function contains nested functions),
-        # then add the FuncDef to the parent function's environment class.
         if self.fn_info.contains_nested:
-            if self.fn_info.is_nested:
-                return self.add_var_to_env_class(fdef, object_rprimitive,
-                                                 self.fn_info.callable_class, reassign=False)
-            return self.add_var_to_env_class(fdef, object_rprimitive, self.fn_info, reassign=False)
+            # If this function is nested, then we have already added it to it's parent function's
+            # environment, so just perform an environment lookup.
+            return self.environment.lookup(fdef)
+
 
         return self.environment.add_local_reg(fdef, object_rprimitive)
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -659,8 +659,8 @@ class Branch(ControlOp):
     # exception, it needs to split into two opcodes and only the first one may fail.
     error_kind = ERR_NEVER
 
-    BOOL_EXPR = 100
-    IS_ERROR = 101  # Check for magic c_error_value (works for arbitary types)
+    BOOL_EXPR = 100  # type: Final
+    IS_ERROR = 101  # type: Final
 
     op_names = {
         BOOL_EXPR: ('%r', 'bool'),
@@ -907,7 +907,7 @@ class EmitterInterface():
         raise NotImplementedError
 
     @abstractmethod
-    def emit_lines(self, *line: str) -> None:
+    def emit_lines(self, *lines: str) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -1336,11 +1336,11 @@ class RaiseStandardError(RegisterOp):
 
     error_kind = ERR_FALSE
 
-    VALUE_ERROR = 'ValueError'
-    ASSERTION_ERROR = 'AssertionError'
-    STOP_ITERATION = 'StopIteration'
-    UNBOUND_LOCAL_ERROR = 'UnboundLocalError'
-    RUNTIME_ERROR = 'RuntimeError'
+    VALUE_ERROR = 'ValueError'  # type: Final
+    ASSERTION_ERROR = 'AssertionError'  # type: Final
+    STOP_ITERATION = 'StopIteration'  # type: Final
+    UNBOUND_LOCAL_ERROR = 'UnboundLocalError'  # type: Final
+    RUNTIME_ERROR = 'RuntimeError'  # type: Final
 
     def __init__(self, class_name: str, value: Optional[Union[str, Value]], line: int) -> None:
         super().__init__(line)

--- a/mypyc/prebuildvisitor.py
+++ b/mypyc/prebuildvisitor.py
@@ -25,8 +25,8 @@ class PreBuildVisitor(TraverserVisitor):
         self.funcs = []  # type: List[FuncItem]
         # The set of property setters
         self.prop_setters = set()  # type: Set[FuncDef]
-        # A map from any function that contains nested functions to a tuple consisting
-        # of a set of all the functions that are nested within it.
+        # A map from any function that contains nested functions to
+        # a set of all the functions that are nested within it.
         self.encapsulating_funcs = dict()  # type: Dict[FuncItem, Set[FuncItem]]
         # A map from a nested func to it's parent/encapsulating func.
         self.nested_funcs = dict()  # type: Dict[FuncItem, FuncItem]

--- a/mypyc/prebuildvisitor.py
+++ b/mypyc/prebuildvisitor.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple, Optional
 
 from mypy.nodes import (
     Decorator, Expression, FuncDef, FuncItem, LambdaExpr, NameExpr, SymbolNode, Var, MemberExpr
@@ -25,8 +25,11 @@ class PreBuildVisitor(TraverserVisitor):
         self.funcs = []  # type: List[FuncItem]
         # The set of property setters
         self.prop_setters = set()  # type: Set[FuncDef]
-        self.encapsulating_funcs = set()  # type: Set[FuncItem]
-        self.nested_funcs = set()  # type: Set[FuncItem]
+        # A map from any function that contains nested functions to a tuple consisting
+        # of a set of all the functions that are nested within it.
+        self.encapsulating_funcs = dict()  # type: Dict[FuncItem, Set[FuncItem]]
+        # A map from a nested func to it's parent/encapsulating func.
+        self.nested_funcs = dict()  # type: Dict[FuncItem, FuncItem]
         self.funcs_to_decorators = {}  # type: Dict[FuncDef, List[Expression]]
 
     def add_free_variable(self, symbol: SymbolNode) -> None:
@@ -50,16 +53,19 @@ class PreBuildVisitor(TraverserVisitor):
 
     def visit_func(self, func: FuncItem) -> None:
         # If there were already functions or lambda expressions defined in the function stack, then
-        # note the previous FuncItem has containing a nested function and the current FuncItem as
+        # note the previous FuncItem as containing a nested function and the current FuncItem as
         # being a nested function.
         if self.funcs:
-            self.encapsulating_funcs.add(self.funcs[-1])
-            self.nested_funcs.add(func)
+            # Add the new func to the set of nested funcs within the func at top of the func stack.
+            self.encapsulating_funcs.setdefault(self.funcs[-1], set()).add(func)
+            # Add the func at top of the func stack as the parent of new func.
+            self.nested_funcs[func] = self.funcs[-1]
+
         self.funcs.append(func)
         super().visit_func(func)
         self.funcs.pop()
 
-    def visit_func_def(self, fdef: FuncDef) -> None:
+    def visit_func_def(self, fdef: FuncItem) -> None:
         self.visit_func(fdef)
 
     def visit_lambda_expr(self, expr: LambdaExpr) -> None:
@@ -69,17 +75,38 @@ class PreBuildVisitor(TraverserVisitor):
         if isinstance(expr.node, (Var, FuncDef)):
             self.visit_symbol_node(expr.node)
 
+    # Check if child is contained within fdef (possibly indirectly within
+    # multiple nested functions).
+    def is_parent(self, fitem: FuncItem, child: FuncItem) -> bool:
+        if child in self.nested_funcs:
+            parent = self.nested_funcs[child]
+            if parent == fitem:
+                return True
+            return self.is_parent(fitem, parent)
+        return False
+
     def visit_symbol_node(self, symbol: SymbolNode) -> None:
         if not self.funcs:
             # If the list of FuncDefs is empty, then we are not inside of a function and hence do
             # not need to do anything regarding free variables.
             return
 
-        if symbol in self.symbols_to_funcs and self.symbols_to_funcs[symbol] != self.funcs[-1]:
-            # If the SymbolNode instance has already been visited before, and it was declared in a
-            # FuncDef outside of the current FuncDef that is being visted, then it is a free symbol
-            # because it is being visited again.
-            self.add_free_variable(symbol)
+        if symbol in self.symbols_to_funcs:
+            orig_func = self.symbols_to_funcs[symbol]
+            if self.is_parent(self.funcs[-1], orig_func):
+                # If the function in which the symbol was originally seen is nested
+                # within the function currently being visited, fix the free_variable
+                # and symbol_to_funcs dictionaries.
+                self.symbols_to_funcs[symbol] = self.funcs[-1]
+                self.free_variables.setdefault(self.funcs[-1], set()).add(symbol)
+
+            elif self.is_parent(orig_func, self.funcs[-1]):
+                # If the SymbolNode instance has already been visited before,
+                # and it was declared in a FuncDef not nested within the current
+                # FuncDef being visited, then it is a free symbol because it is
+                # being visited again.
+                self.add_free_variable(symbol)
+
         else:
             # Otherwise, this is the first time the SymbolNode is being visited. We map the
             # SymbolNode to the current FuncDef being visited to note where it was first visited.

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2219,8 +2219,36 @@ def mutual_recursion(start : int) -> int:
         k -= 1
         return f1(k)
 
-    return f1(start) 
+    return f1(start)
 
+def topLayer() -> int:
+    def middleLayer() -> int:
+        def bottomLayer() -> int:
+            return x
+
+        return bottomLayer()
+
+    x = 1
+
+    return middleLayer()
+
+def nest1() -> str:
+    def nest2() -> str:
+        def nest3() -> str:
+            def mut1(val: int) -> str:
+                if val <= 0:
+                    return "bottomed"
+                val -= 1
+                return mut2(val)
+            def mut2(val: int) -> str:
+                if val <= 0:
+                        return "bottomed"
+                val -= 1
+                return mut1(val)
+            return mut1(start)
+        return nest3()
+    start = 3
+    return nest2()
 
 def uno(num: float) -> Callable[[str], str]:
     def dos(s: str) -> str:
@@ -2258,7 +2286,8 @@ def third() -> str:
     return 'third: normal function'
 
 [file driver.py]
-from native import outer, inner, first, uno, eins, call_other_inner_func, second, third, f1, outer_func, mutual_recursion
+from native import (outer, inner, first, uno, eins, call_other_inner_func,
+second, third, f1, outer_func, mutual_recursion, topLayer, nest1)
 
 assert outer()() == None
 assert inner() == 'inner: normal function'
@@ -2271,6 +2300,8 @@ assert third() == 'third: normal function'
 assert f1() == 2
 assert outer_func() == 1
 assert mutual_recursion(5) == 0
+assert topLayer() == 1
+assert nest1() == "bottomed"
 
 [case testOverloads]
 from typing import overload, Union, Tuple

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -2200,6 +2200,28 @@ def f1() -> int:
                 return f3()
         return f2()
 
+def outer_func() -> int:
+    def inner_func() -> int:
+        return x
+    x = 1
+    return inner_func()
+
+def mutual_recursion(start : int) -> int:
+    def f1(k : int) -> int:
+        if k <= 0:
+            return 0
+        k -= 1
+        return f2(k)
+
+    def f2(k : int) -> int:
+        if k <= 0:
+            return 0
+        k -= 1
+        return f1(k)
+
+    return f1(start) 
+
+
 def uno(num: float) -> Callable[[str], str]:
     def dos(s: str) -> str:
         return s + '!'
@@ -2236,7 +2258,7 @@ def third() -> str:
     return 'third: normal function'
 
 [file driver.py]
-from native import outer, inner, first, uno, eins, call_other_inner_func, second, third, f1
+from native import outer, inner, first, uno, eins, call_other_inner_func, second, third, f1, outer_func, mutual_recursion
 
 assert outer()() == None
 assert inner() == 'inner: normal function'
@@ -2247,6 +2269,8 @@ assert call_other_inner_func(5) == 21
 assert second() == 'second: normal function'
 assert third() == 'third: normal function'
 assert f1() == 2
+assert outer_func() == 1
+assert mutual_recursion(5) == 0
 
 [case testOverloads]
 from typing import overload, Union, Tuple


### PR DESCRIPTION
This pull request fixes issues with nested name resolution, namely, the following pieces of code would not compile due to our previous method of name resolution:
```
def f1():
    def f2():
        print(x)
    x = 1
```

or
```
def m():
    def f1():
        f2()
    def f2():
        f1()
```
Now, we add free variables and functions defined within a function to that functions environment class before we visit the body of that function, so other functions nested within that function can refer to those variables and functions. This allows for mutual recursion, which mypyc itself uses.

There are also a few "final" type annotations scattered throughout this PR.