### PR TITLE
Support non-extension class compilation

### DIFF
--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -149,7 +149,7 @@ class ModuleGenerator:
             self.define_finals(module.final_names, emitter)
 
             for cl in module.classes:
-                if not cl.is_non_ext:
+                if cl.is_ext_class:
                     generate_class(cl, module_name, emitter)
 
             # Generate Python extension module definitions and module initialization functions.

--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -149,7 +149,8 @@ class ModuleGenerator:
             self.define_finals(module.final_names, emitter)
 
             for cl in module.classes:
-                generate_class(cl, module_name, emitter)
+                if not cl.is_non_ext:
+                    generate_class(cl, module_name, emitter)
 
             # Generate Python extension module definitions and module initialization functions.
             self.generate_module_def(emitter, module_name, module)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1143,9 +1143,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # could refactor this to reduce duplicated code?
         for stmt in cdef.defs.body:
             if isinstance(stmt, FuncDef):
-                # TODO(sanjit): Should probably ignore other plugin generated methods when creating
-                # non-extension classes
-                if stmt.name() == '__init__':
+                # Ignore plugin generated methods when creating non-extension classes
+                assert stmt.name() in cdef.info.names
+                if cdef.info.names[stmt.name()].plugin_generated:
                     continue
 
                 func_ir, func_reg = self.gen_func_item(stmt, stmt.name(),

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1140,8 +1140,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # MYTODO: We will eventually need precise types for annotations
         annotations_dict = self.primitive_op(new_dict_op, [], cdef.line)
         # MYTODO: Handle decorated methods/overloaded methods maybe?
-        # This code is very similar to the visit_class_def code. Probably
-        # should refactor this.
+        # This code is similar to the visit_class_def code. Maybe
+        # could refactor this to reduce duplicated code?
         for stmt in cdef.defs.body:
             if isinstance(stmt, FuncDef):
                 # MYTODO: Should probably ignore other plugin generated methods when creating
@@ -1172,9 +1172,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                     continue
 
                 key = self.load_static_unicode(lvalue.name)
-                # desc = name_ref_ops['builtins.list']
-                # assert desc.result_type is not None
-                # typ = self.add(PrimitiveOp([], desc, stmt.line))
                 typ = self.primitive_op(type_object_op, [], stmt.line)
                 self.primitive_op(dict_set_item_op, [annotations_dict, key, typ], stmt.line)
 
@@ -1219,8 +1216,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         decorators = cdef.decorators
         dec_class = type_obj
         for d in reversed(decorators):
-            # if d.name == 'dataclass':
-            #     continue
             decorator = d.accept(self)
             assert isinstance(decorator, Value)
             dec_class = self.py_call(decorator, [dec_class], dec_class.line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1962,7 +1962,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 return reg
             assert False, target.base.type
         if isinstance(target, AssignmentTargetAttr):
-            if isinstance(target.obj.type, RInstance):
+            if isinstance(target.obj.type, RInstance) and not target.obj.type.class_ir.is_non_ext:
                 return self.add(GetAttr(target.obj, target.attr, line))
             else:
                 return self.py_get_attr(target.obj, target.attr, line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3093,7 +3093,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.py_method_call(base, name, arg_values, base.line, arg_kinds, arg_names)
 
         # If the base type is one of ours, do a MethodCall
-        if isinstance(base.type, RInstance) and not base.type.class_ir.builtin_base:
+        if (isinstance(base.type, RInstance) and base.type.class_ir.is_ext_class
+                and not base.type.class_ir.builtin_base):
             if base.type.class_ir.has_method(name):
                 decl = base.type.class_ir.method_decl(name)
                 if arg_kinds is None:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -217,19 +217,21 @@ def is_non_ext_class(cdef: ClassDef) -> bool:
 
 def mark_non_ext_classes(class_map: Dict[TypeInfo, ClassIR]) -> None:
     seen = set()  # type: Set[TypeInfo]
-    to_check = list(class_map.keys())
+    stack = list(class_map.keys())
     to_mark = set()  # type: Set[TypeInfo]
-    while to_check:
-        typ = to_check.pop()
+    while stack:
+        typ = stack.pop()
+        if typ in seen and typ not in to_mark:
+            continue
         ir = class_map[typ]
         seen.add(typ)
         ir.is_non_ext = True if typ in to_mark else is_non_ext_class(typ.defn)
         if ir.is_non_ext:
             # Base class chains will be marked as non-extensions
             for base_type in typ.bases:
-                if base_type.type not in seen and base_type.type in class_map:
+                if base_type.type not in to_mark and base_type.type in class_map:
                     to_mark.add(base_type.type)
-                    to_check.append(base_type.type)
+                    stack.append(base_type.type)
 
 
 def is_trait(cdef: ClassDef) -> bool:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -2783,7 +2783,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         return self.add(Call(decl, args, line))
 
     def visit_call_expr(self, expr: CallExpr) -> Value:
-        # Annoying special case for the dataclasses field function calls because
+        # Annoying special case for dataclasses 'field' function calls because
         # the mypy dataclass plugin typechecks such a call using the types
         # of the parameters to the default and default_factory
         # arguments, resulting in attempted coercions that throw a runtime error.

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1136,9 +1136,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def populate_class_dict(self, cdef: ClassDef) -> Value:
         class_dict = self.primitive_op(new_dict_op, [], cdef.line)
-        # TODO(sanjit): We will eventually need precise types for annotations
         annotations_dict = self.primitive_op(new_dict_op, [], cdef.line)
-        # TODO(sanjit): Handle decorated methods/overloaded methods maybe?
+        # TODO: Handle decorated/overloaded methods.
         # This code is similar to the visit_class_def code. Maybe
         # could refactor this to reduce duplicated code?
         for stmt in cdef.defs.body:
@@ -1170,6 +1169,9 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                                stmt.line)
                     continue
 
+                # We populate __annotations__ because dataclasses uses it to determine
+                # which attributes to compute on.
+                # TODO: Maybe generate more precise types for annotations
                 key = self.load_static_unicode(lvalue.name)
                 typ = self.primitive_op(type_object_op, [], stmt.line)
                 self.primitive_op(dict_set_item_op, [annotations_dict, key, typ], stmt.line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -4580,7 +4580,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         curr_env_reg = None
         if self.fn_info.is_generator:
             curr_env_reg = self.fn_info.generator_class.curr_env_reg
-        elif self.fn_info.is_nested or self.fn_info.in_non_ext:
+        elif self.fn_info.is_nested:
             curr_env_reg = self.fn_info.callable_class.curr_env_reg
         elif self.fn_info.contains_nested:
             curr_env_reg = self.fn_info.curr_env_reg

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1615,7 +1615,6 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         rt_arg = RuntimeArg(SELF_NAME, RInstance(cls))
         arg = self.read(self.add_self_to_env(cls), line)
         self.ret_types[-1] = sig.ret_type
-
         retval = self.add(GetAttr(arg, target.name, line))
         retbox = self.coerce(retval, sig.ret_type, line)
         self.add(Return(retbox))
@@ -2736,7 +2735,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             return self.get_attr(obj, expr.name, self.node_type(expr), expr.line)
 
     def get_attr(self, obj: Value, attr: str, result_type: RType, line: int) -> Value:
-        if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(attr):
+        if (isinstance(obj.type, RInstance) and obj.type.class_ir.is_ext_class
+                and obj.type.class_ir.has_attr(attr)):
             return self.add(GetAttr(obj, attr, line))
         elif isinstance(obj.type, RUnion):
             return self.union_get_attr(obj, obj.type, attr, result_type, line)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1137,14 +1137,14 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
     def populate_class_dict(self, cdef: ClassDef) -> Value:
         class_dict = self.primitive_op(new_dict_op, [], cdef.line)
-        # MYTODO: We will eventually need precise types for annotations
+        # TODO(sanjit): We will eventually need precise types for annotations
         annotations_dict = self.primitive_op(new_dict_op, [], cdef.line)
-        # MYTODO: Handle decorated methods/overloaded methods maybe?
+        # TODO(sanjit): Handle decorated methods/overloaded methods maybe?
         # This code is similar to the visit_class_def code. Maybe
         # could refactor this to reduce duplicated code?
         for stmt in cdef.defs.body:
             if isinstance(stmt, FuncDef):
-                # MYTODO: Should probably ignore other plugin generated methods when creating
+                # TODO(sanjit): Should probably ignore other plugin generated methods when creating
                 # non-extension classes
                 if stmt.name() == '__init__':
                     continue
@@ -1202,7 +1202,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         type_obj = self.primitive_op(type_object_op, [], cdef.line)
         name = self.load_static_unicode(cdef.name)
         class_dict = self.populate_class_dict(cdef)
-        # MYTODO: Fill in the bases list, putting off on first pass
+        # TODO(sanjit): Fill in the bases list, putting off on first pass
         bases = self.primitive_op(new_tuple_op, [], cdef.line)
         class_type_obj = self.py_call(type_obj, [name, bases, class_dict], cdef.line)
         return class_type_obj

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -976,7 +976,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
 
         classes = [node for node in mypyfile.defs if isinstance(node, ClassDef)]
 
-        # Collect all undecorated classes.
+        # Collect all classes.
         for cls in classes:
             ir = self.mapper.type_to_ir[cls.info]
             self.classes.append(ir)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1537,11 +1537,11 @@ class ClassIR:
     """
     def __init__(self, name: str, module_name: str, is_trait: bool = False,
                  is_generated: bool = False, is_abstract: bool = False,
-                 is_non_ext: bool = False) -> None:
+                 is_ext_class: bool = True) -> None:
         self.name = name
         self.module_name = module_name
         self.is_trait = is_trait
-        self.is_non_ext = is_non_ext
+        self.is_ext_class = is_ext_class
         self.is_abstract = is_abstract
         self.is_generated = is_generated
         self.inherits_python = False

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1679,6 +1679,23 @@ class ClassIR:
         return sorted(concrete, key=lambda c: (len(c.children), c.name))
 
 
+class NonExtClassInfo:
+    """Information needed to construct a non-extension class.
+
+
+    Includes the class dictionary, a tuple of base classes, and
+    the class annotations dictionary.
+    """
+
+    def __init__(self,
+            non_ext_dict: Value,
+            non_ext_bases: Value,
+            non_ext_anns: Value) -> None:
+        self.dict = non_ext_dict
+        self.bases = non_ext_bases
+        self.anns = non_ext_anns
+
+
 LiteralsMap = Dict[Tuple[Type[object], Union[int, float, str, bytes, complex]], str]
 
 

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1586,15 +1586,6 @@ class ClassIR:
         # in a few ad-hoc cases.
         self.builtin_base = None  # type: Optional[str]
 
-        # If the class is to be treated as a non-extension class, typ_obj represents
-        # the dynamically created class created using the type() constructor. We need to
-        # feed in a dict of class attributes, and TODO: a tuple of base classes in MRO order
-        # to the type() constuctor.
-        self.type_obj = None  # type: Optional[Value]
-        self.type_dict = None  # type: Optional[Value]
-        self.type_bases = None  # type: Optional[Value]
-        self.type_anns = None  # type: Optional[Value]
-
     def real_base(self) -> Optional['ClassIR']:
         """Return the actual concrete base class, if there is one."""
         if len(self.mro) > 1 and not self.mro[1].is_trait:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1536,7 +1536,8 @@ class ClassIR:
     This also describes the runtime structure of native instances.
     """
     def __init__(self, name: str, module_name: str, is_trait: bool = False,
-                 is_generated: bool = False, is_abstract: bool = False, is_non_ext: bool = False) -> None:
+                 is_generated: bool = False, is_abstract: bool = False,
+                 is_non_ext: bool = False) -> None:
         self.name = name
         self.module_name = module_name
         self.is_trait = is_trait

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1586,6 +1586,15 @@ class ClassIR:
         # in a few ad-hoc cases.
         self.builtin_base = None  # type: Optional[str]
 
+        # If the class is to be treated as a non-extension class, typ_obj represents
+        # the dynamically created class created using the type() constructor. We need to
+        # feed in a dict of class attributes, and TODO: a tuple of base classes in MRO order
+        # to the type() constuctor.
+        self.type_obj = None  # type: Optional[Value]
+        self.type_dict = None  # type: Optional[Value]
+        self.type_bases = None  # type: Optional[Value]
+        self.type_anns = None  # type: Optional[Value]
+
     def real_base(self) -> Optional['ClassIR']:
         """Return the actual concrete base class, if there is one."""
         if len(self.mro) > 1 and not self.mro[1].is_trait:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1536,10 +1536,11 @@ class ClassIR:
     This also describes the runtime structure of native instances.
     """
     def __init__(self, name: str, module_name: str, is_trait: bool = False,
-                 is_generated: bool = False, is_abstract: bool = False) -> None:
+                 is_generated: bool = False, is_abstract: bool = False, is_non_ext: bool = False) -> None:
         self.name = name
         self.module_name = module_name
         self.is_trait = is_trait
+        self.is_non_ext = is_non_ext
         self.is_abstract = is_abstract
         self.is_generated = is_generated
         self.inherits_python = False

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -290,7 +290,8 @@ py_calc_meta_op = custom_op(
     error_kind=ERR_MAGIC,
     format_str='{dest} = py_calc_metaclass({comma_args})',
     emit=simple_emit(
-        '{dest} = (PyObject*) _PyType_CalculateMetaclass((PyTypeObject *){args[0]}, {args[1]});')
+        '{dest} = (PyObject*) _PyType_CalculateMetaclass((PyTypeObject *){args[0]}, {args[1]});'),
+    is_borrowed = True
 )
 
 py_delattr_op = func_op(

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -379,6 +379,12 @@ type_op = func_op(
     error_kind=ERR_NEVER,
     emit=call_emit('PyObject_Type'))
 
+type_object_op = custom_op(result_type=object_rprimitive,
+                           arg_types=[],
+                           format_str='{dest} = builtins.type :: object',
+                           error_kind=ERR_NEVER,
+                           emit=name_emit('(PyObject*) &PyType_Type'))
+
 func_op(name='builtins.len',
         arg_types=[object_rprimitive],
         result_type=int_rprimitive,

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -276,12 +276,21 @@ py_setattr_op = func_op(
     emit=call_negative_bool_emit('PyObject_SetAttr')
 )
 
-func_op(
+py_hasattr_op = func_op(
     name='builtins.hasattr',
     arg_types=[object_rprimitive, object_rprimitive],
     result_type=bool_rprimitive,
     error_kind=ERR_NEVER,
     emit=call_emit('PyObject_HasAttr')
+)
+
+py_calc_meta_op = custom_op(
+    arg_types=[object_rprimitive, object_rprimitive],
+    result_type=object_rprimitive,
+    error_kind=ERR_MAGIC,
+    format_str='{dest} = py_calc_metaclass({comma_args})',
+    emit=simple_emit(
+        '{dest} = (PyObject*) _PyType_CalculateMetaclass((PyTypeObject *){args[0]}, {args[1]});')
 )
 
 py_delattr_op = func_op(

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -379,11 +379,10 @@ type_op = func_op(
     error_kind=ERR_NEVER,
     emit=call_emit('PyObject_Type'))
 
-type_object_op = custom_op(result_type=object_rprimitive,
-                           arg_types=[],
-                           format_str='{dest} = builtins.type :: object',
-                           error_kind=ERR_NEVER,
-                           emit=name_emit('(PyObject*) &PyType_Type'))
+type_object_op = name_ref_op('builtins.type',
+                       result_type=object_rprimitive,
+                       error_kind=ERR_NEVER,
+                       emit=name_emit('(PyObject*) &PyType_Type'))
 
 func_op(name='builtins.len',
         arg_types=[object_rprimitive],

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -135,8 +135,7 @@ class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplem
     pass
 
 @decorator
-class Wrong(metaclass=NeverMetaclass):  # E: Metaclasses are not supported  \
-                                        # E: Class decorators are not supported
+class Wrong(metaclass=NeverMetaclass):  # E: Metaclasses are not supported
     pass
 
 class Concrete1:

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -134,9 +134,6 @@ def decorator(x: Any) -> Any:
 class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented
     pass
 
-class Wrong(metaclass=NeverMetaclass):  # E: Metaclasses are not supported
-    pass
-
 class Concrete1:
     pass
 

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -134,7 +134,6 @@ def decorator(x: Any) -> Any:
 class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented
     pass
 
-@decorator
 class Wrong(metaclass=NeverMetaclass):  # E: Metaclasses are not supported
     pass
 

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -115,6 +115,7 @@ class TestEnum(Enum):
 assert TestEnum.test() == 3
 
 [file driver.py]
+import sys
 
 # enum introduced in 3.4
 version = sys.version_info[:2]
@@ -177,7 +178,6 @@ class Person4:
         return self._name
 
 [file driver.py]
-from testutil import assertRaises
 import sys
 
 # Dataclasses introduced in 3.7

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -115,6 +115,12 @@ class TestEnum(Enum):
 assert TestEnum.test() == 3
 
 [file driver.py]
+
+# enum introduced in 3.4
+version = sys.version_info[:2]
+if version[0] < 3 or version[1] < 4:
+    exit()
+
 from native import TestEnum
 assert TestEnum.a.name == 'a'
 assert TestEnum.a.value == 1

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -38,9 +38,7 @@ i9 = Person3(age = 5, name = 'new_robot')
 assert i9.age == 5
 assert i9.name == 'new_robot'
 
-#MYTODO: Get fields working
-# field(default = 'hello')
-
+# MYTODO: Get fields working
 # @dataclass
 # class Person4:
 #     friend_ids : List[int] = field(default_factory = list)

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -59,7 +59,7 @@ assert hasattr(c, 'x')
 
 [case testDataClass]
 from dataclasses import dataclass, field
-from typing import Set, List
+from typing import Set, List, Callable, Any
 
 @dataclass
 class Person1:
@@ -88,8 +88,21 @@ class Person3:
     def get_friendIDs(self) -> List[int]:
         return self.friendIDs
 
+def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
+    def f(a: Any) -> int:
+        return g(a) + 1 
+    return f
+
+@dataclass
+class Person4:
+    age : int
+
+    @get_next_age
+    def get_age(self) -> int:
+        return self.age
+
 [file driver.py]
-from native import Person1, Person2, Person3
+from native import Person1, Person2, Person3, Person4
 i1 = Person1(age = 5, name = 'robot')
 assert i1.age == 5
 assert i1.name == 'robot'
@@ -113,6 +126,8 @@ i6.set_age(10)
 assert i6.get_age() == 10
 i6.add_friendID(4)
 assert i6.get_friendIDs() == [1,2,3,4]
+i7 = Person4(age = 5)
+assert i7.get_age() == 6
 
 [case testGetAttribute]
 class C:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -96,10 +96,15 @@ def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
 @dataclass
 class Person4:
     age : int
+    _name : str = 'Bot'
 
     @get_next_age
     def get_age(self) -> int:
         return self.age
+
+    @property
+    def name(self) -> str:
+        return self._name
 
 [file driver.py]
 from native import Person1, Person2, Person3, Person4
@@ -130,6 +135,7 @@ i7 = Person4(age = 5)
 assert i7.get_age() == 6
 i7.age += 3
 assert i7.age == 8
+assert i7.name == 'Bot'
 
 [case testGetAttribute]
 class C:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -47,7 +47,7 @@ assert i9.get_age() == 5
 i9.set_age(10)
 assert i9.get_age() == 10
 
-# MYTODO: Get fields working
+# TODO(sanjit): Get fields working
 # @dataclass
 # class Person4:
 #     friend_ids : List[int] = field(default_factory = list)

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -1,3 +1,57 @@
+[case testDataClass]
+from dataclasses import dataclass, field
+from typing import Set, List
+
+@dataclass
+class Person1:
+    age : int
+    name : str
+
+i4 = Person1(age = 5, name = 'robot')
+assert i4.age == 5
+assert i4.name == 'robot'
+
+@dataclass
+class Person2:
+    age : int
+    name : str = 'robot'
+
+i5 = Person2(age = 5)
+assert i5.age == 5
+assert i5.name == 'robot'
+i6 = Person2(age = 5, name = 'new_robot')
+assert i6.age == 5
+assert i6.name == 'new_robot'
+
+@dataclass
+class Person3:
+    age : int = 6
+    name : str = 'robot'
+
+i7 = Person3()
+assert i7.age == 6
+assert i7.name == 'robot'
+i8 = Person3(age = 5)
+assert i8.age == 5
+assert i8.name == 'robot'
+i9 = Person3(age = 5, name = 'new_robot')
+assert i9.age == 5
+assert i9.name == 'new_robot'
+
+#MYTODO: Get fields working
+# field(default = 'hello')
+
+# @dataclass
+# class Person4:
+#     friend_ids : List[int] = field(default_factory = list)
+
+# i10 = Person4(friend_ids = 1)
+# assert i10.friend_ids == 1
+
+
+[file driver.py]
+from native import Person1, Person2, Person3
+
 [case testEmptyClass]
 class Empty: pass
 

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -28,6 +28,12 @@ class Person3:
     age : int = 6
     name : str = 'robot'
 
+    def get_age(self) -> int:
+        return (self.age)
+
+    def set_age(self, new_age : int) -> None:
+        self.age = new_age
+
 i7 = Person3()
 assert i7.age == 6
 assert i7.name == 'robot'
@@ -37,6 +43,9 @@ assert i8.name == 'robot'
 i9 = Person3(age = 5, name = 'new_robot')
 assert i9.age == 5
 assert i9.name == 'new_robot'
+assert i9.get_age() == 5
+i9.set_age(10)
+assert i9.get_age() == 10
 
 # MYTODO: Get fields working
 # @dataclass

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -1,64 +1,3 @@
-[case testDataClass]
-from dataclasses import dataclass, field
-from typing import Set, List
-
-@dataclass
-class Person1:
-    age : int
-    name : str
-
-i4 = Person1(age = 5, name = 'robot')
-assert i4.age == 5
-assert i4.name == 'robot'
-
-@dataclass
-class Person2:
-    age : int
-    name : str = 'robot'
-
-i5 = Person2(age = 5)
-assert i5.age == 5
-assert i5.name == 'robot'
-i6 = Person2(age = 5, name = 'new_robot')
-assert i6.age == 5
-assert i6.name == 'new_robot'
-
-@dataclass
-class Person3:
-    age : int = 6
-    name : str = 'robot'
-
-    def get_age(self) -> int:
-        return (self.age)
-
-    def set_age(self, new_age : int) -> None:
-        self.age = new_age
-
-i7 = Person3()
-assert i7.age == 6
-assert i7.name == 'robot'
-i8 = Person3(age = 5)
-assert i8.age == 5
-assert i8.name == 'robot'
-i9 = Person3(age = 5, name = 'new_robot')
-assert i9.age == 5
-assert i9.name == 'new_robot'
-assert i9.get_age() == 5
-i9.set_age(10)
-assert i9.get_age() == 10
-
-# TODO(sanjit): Get fields working
-# @dataclass
-# class Person4:
-#     friend_ids : List[int] = field(default_factory = list)
-
-# i10 = Person4(friend_ids = 1)
-# assert i10.friend_ids == 1
-
-
-[file driver.py]
-from native import Person1, Person2, Person3
-
 [case testEmptyClass]
 class Empty: pass
 
@@ -117,6 +56,63 @@ assert hasattr(c, 'x')
 1000000000000000000000000000000
 1000000000000000000000000000001
 1000000000000000000000000000002
+
+[case testDataClass]
+from dataclasses import dataclass, field
+from typing import Set, List
+
+@dataclass
+class Person1:
+    age : int
+    name : str
+
+@dataclass
+class Person2:
+    age : int
+    name : str = 'robot'
+
+@dataclass
+class Person3:
+    age : int = field(default = 6)
+    friendIDs : List[int] = field(default_factory = list)
+
+    def get_age(self) -> int:
+        return (self.age)
+
+    def set_age(self, new_age : int) -> None:
+        self.age = new_age
+
+    def add_friendID(self, fid : int) -> None:
+        self.friendIDs.append(fid)
+
+    def get_friendIDs(self) -> List[int]:
+        return self.friendIDs
+
+[file driver.py]
+from native import Person1, Person2, Person3
+i1 = Person1(age = 5, name = 'robot')
+assert i1.age == 5
+assert i1.name == 'robot'
+i2 = Person2(age = 5)
+assert i2.age == 5
+assert i2.name == 'robot'
+i3 = Person2(age = 5, name = 'new_robot')
+assert i3.age == 5
+assert i3.name == 'new_robot'
+i4 = Person3()
+assert i4.age == 6
+assert i4.friendIDs == []
+i5 = Person3(age = 5)
+assert i5.age == 5
+assert i5.friendIDs == []
+i6 = Person3(age = 5, friendIDs = [1,2,3])
+assert i6.age == 5
+assert i6.friendIDs == [1,2,3]
+assert i6.get_age() == 5
+i6.set_age(10)
+assert i6.get_age() == 10
+i6.add_friendID(4)
+assert i6.get_friendIDs() == [1,2,3,4]
 
 [case testGetAttribute]
 class C:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -107,6 +107,13 @@ class Person4:
         return self._name
 
 [file driver.py]
+from testutil import assertRaises
+import sys
+# Dataclasses introduced in 3.7
+version = sys.version_info[:2]
+if version[0] < 3 or version[1] < 7:
+    assertRaises(ValueError, "Dataclasses introduced in 3.7")
+
 from native import Person1, Person2, Person3, Person4
 i1 = Person1(age = 5, name = 'robot')
 assert i1.age == 5

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -109,10 +109,11 @@ class Person4:
 [file driver.py]
 from testutil import assertRaises
 import sys
+
 # Dataclasses introduced in 3.7
 version = sys.version_info[:2]
 if version[0] < 3 or version[1] < 7:
-    assertRaises(ValueError, "Dataclasses introduced in 3.7")
+    exit()
 
 from native import Person1, Person2, Person3, Person4
 i1 = Person1(age = 5, name = 'robot')

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -115,13 +115,6 @@ class TestEnum(Enum):
 assert TestEnum.test() == 3
 
 [file driver.py]
-import sys
-
-# enum introduced in 3.4
-version = sys.version_info[:2]
-if version[0] < 3 or version[1] < 4:
-    exit()
-
 from native import TestEnum
 assert TestEnum.a.name == 'a'
 assert TestEnum.a.value == 1

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -85,7 +85,7 @@ class A(B):
         self.a = 1
 
     @classmethod
-    def constant(self) -> int:
+    def constant(cls) -> int:
         return 4
 
     def get_a(self) -> int:
@@ -135,7 +135,7 @@ class Person2:
     age : int
     name : str = 'robot'
 
-@dataclass
+@dataclass(order = True)
 class Person3:
     age : int = field(default = 6)
     friendIDs : List[int] = field(default_factory = list)
@@ -207,6 +207,11 @@ assert i7.get_age() == 6
 i7.age += 3
 assert i7.age == 8
 assert i7.name == 'Bot'
+i8 = Person3(age = 1, friendIDs = [1,2])
+i9 = Person3(age = 1, friendIDs = [1,2])
+assert i8 == i9
+i8.age = 2
+assert i8 > i9
 
 [case testGetAttribute]
 class C:

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -57,6 +57,70 @@ assert hasattr(c, 'x')
 1000000000000000000000000000001
 1000000000000000000000000000002
 
+[case testNonExtInheritance]
+from typing import Any
+
+def decorator(cls) -> Any:
+    return cls
+
+class C:
+    def __init__(self) -> None:
+        self.c = 3
+
+    def get_c(self) -> int:
+        return self.c
+
+class B(C):
+    def __init__(self) -> None:
+        super().__init__()
+        self.b = 2
+
+    def get_b(self) -> int:
+        return self.b
+
+@decorator
+class A(B):
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = 1
+
+    @classmethod
+    def constant(self) -> int:
+        return 4
+
+    def get_a(self) -> int:
+        return self.a
+
+[file driver.py]
+from native import A
+a = A()
+assert a.a == 1
+assert a.b == 2
+assert a.c == 3
+assert a.get_a() == 1
+assert a.get_b() == 2
+assert a.get_c() == 3
+
+[case testEnum]
+from enum import Enum
+
+class TestEnum(Enum):
+    a : int = 1
+    b : int = 2
+
+    @classmethod
+    def test(cls) -> int:
+        return 3
+
+assert TestEnum.test() == 3
+
+[file driver.py]
+from native import TestEnum
+assert TestEnum.a.name == 'a'
+assert TestEnum.a.value == 1
+assert TestEnum.b.name == 'b'
+assert TestEnum.b.value == 2
+
 [case testDataClass]
 from dataclasses import dataclass, field
 from typing import Set, List, Callable, Any

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -128,6 +128,8 @@ i6.add_friendID(4)
 assert i6.get_friendIDs() == [1,2,3,4]
 i7 = Person4(age = 5)
 assert i7.get_age() == 6
+i7.age += 3
+assert i7.age == 8
 
 [case testGetAttribute]
 class C:


### PR DESCRIPTION
This PR introduces support for compiling classes as non-extension classes via calls to metaclass constructors. Using this non-extension mechanism, this PR supports compiling dataclasses (#495) and Enums (and in theory, compilation of other classes that use metaclasses other than type). Currently, classes are compiled via this non-extension class mechanism if they are decorated, or have a user-specified metaclass other than ABCMeta, TypingMeta, or GenericMeta.

The current goal is to be able to use non-extension classes to support a de-optimized version of dataclasses and enums, and in the future, do some optimization work to make them faster.

Currently, non-extension classes do not support property setters and overloaded functions.