### PR TITLE
Set the strict_optional flag in genops

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -50,6 +50,7 @@ from mypy.types import (
 from mypy.visitor import ExpressionVisitor, StatementVisitor
 from mypy.subtypes import is_named_instance
 from mypy.checkexpr import map_actuals_to_formals
+from mypy.state import strict_optional_set
 
 from mypyc.common import (
     ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, TEMP_ATTR_NAME, LAMBDA_NAME,
@@ -130,6 +131,7 @@ class Errors:
             print(error)
 
 
+@strict_optional_set(True)  # Turn on strict optional for any type manipulations we do
 def build_ir(modules: List[MypyFile],
              graph: Graph,
              types: Dict[Expression, Type],

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -14,7 +14,7 @@ It would be translated to something that conceptually looks like this:
    return r3
 """
 from typing import (
-    Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, cast, overload,
+    TypeVar, Callable, Dict, List, Tuple, Optional, Union, Sequence, Set, Any, cast, overload,
 )
 MYPY = False
 if MYPY:
@@ -130,8 +130,12 @@ class Errors:
         for error in self._errors.new_messages():
             print(error)
 
+# The stubs for callable contextmanagers are busted so cast it to the
+# right type...
+F = TypeVar('F', bound=Callable[..., Any])
+strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
 
-@strict_optional_set(True)  # Turn on strict optional for any type manipulations we do
+@strict_optional_dec  # Turn on strict optional for any type manipulations we do
 def build_ir(modules: List[MypyFile],
              graph: Graph,
              types: Dict[Expression, Type],

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -130,10 +130,12 @@ class Errors:
         for error in self._errors.new_messages():
             print(error)
 
+
 # The stubs for callable contextmanagers are busted so cast it to the
 # right type...
 F = TypeVar('F', bound=Callable[..., Any])
 strict_optional_dec = cast(Callable[[F], F], strict_optional_set(True))
+
 
 @strict_optional_dec  # Turn on strict optional for any type manipulations we do
 def build_ir(modules: List[MypyFile],

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -4271,15 +4271,29 @@ test()
 
 [case testIterTypeTrickiness]
 # Test inferring the type of a for loop body doesn't cause us grief
-# Extracted from something that broke in mypy
+# Extracted from somethings that broke in mypy
 
+from typing import Optional
+
+# really I only care that this one build
 def foo(x: object) -> None:
     if isinstance(x, dict):
         for a in x:
             pass
 
+def bar(x: Optional[str]) -> None:
+    vars = (
+        ("a", 'lol'),
+        ("b", 'asdf'),
+        ("lol", x),
+        ("an int", 10),
+    )
+    for name, value in vars:
+        pass
+
 [file driver.py]
-# really I only care it builds
+from native import bar
+bar(None)
 
 [case testComplicatedArgs]
 from typing import Tuple, Dict
@@ -4441,15 +4455,3 @@ with assertRaises(TypeError, "varargs4() missing required keyword-only argument 
     varargs4(1, 2, 3)
 with assertRaises(TypeError, "varargs4() missing required argument 'a' (pos 1)"):
     varargs4(y=20)
-
-[case testIterTypeTrickiness]
-# Test inferring the type of a for loop body doesn't cause us grief
-# Extracted from something that broke in mypy
-
-def foo(x: object) -> None:
-    if isinstance(x, dict):
-        for a in x:
-            pass
-
-[file driver.py]
-# really I only care it builds


### PR DESCRIPTION
Otherwise some type manipulations we do for inferring for loop
variable types is broken. Since mypyc only supports strict-optional
mode, we just set it unconditionally instead of setting it per-module.