### PR TITLE
Generator and non-extension class fixes

### DIFF
--- a/mypyc/analysis.py
+++ b/mypyc/analysis.py
@@ -5,8 +5,7 @@ from abc import abstractmethod
 from typing import Dict, Tuple, List, Set, TypeVar, Iterator, Generic, Optional, Iterable, Union
 
 from mypyc.ops import (
-    Value, Register,
-    ControlOp,
+    Value, ControlOp,
     BasicBlock, OpVisitor, Assign, LoadInt, LoadErrorValue, RegisterOp, Goto, Branch, Return, Call,
     Environment, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadStatic, InitStatic, PrimitiveOp, MethodCall, RaiseStandardError,

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -21,12 +21,10 @@ hackily decide based on whether setuptools has been imported already.
 import glob
 import sys
 import os.path
-import subprocess
 import hashlib
 import time
-import shutil
 
-from typing import List, Tuple, Any, Optional, Union, Dict, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 MYPY = False
 if MYPY:
     from typing import NoReturn
@@ -51,7 +49,7 @@ if not USE_SETUPTOOLS:
     from distutils.core import setup, Extension
     from distutils.command.build_ext import build_ext  # type: ignore
 else:
-    from setuptools import setup, Extension  # type: ignore
+    from setuptools import setup, Extension  # type: ignore  # noqa
     from setuptools.command.build_ext import build_ext  # type: ignore
 
 from distutils import sysconfig, ccompiler

--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -8,13 +8,12 @@ from mypyc.common import (
     FAST_ISINSTANCE_MAX_SUBCLASSES
 )
 from mypyc.ops import (
-    Any, AssignmentTarget, Environment, BasicBlock, Value, Register, RType, RTuple, RInstance,
-    RUnion, RPrimitive, RVoid,
-    RTypeVisitor,
+    Environment, BasicBlock, Value, RType, RTuple, RInstance,
+    RUnion, RPrimitive,
     is_float_rprimitive, is_bool_rprimitive, is_int_rprimitive, is_short_int_rprimitive,
     short_name, is_list_rprimitive, is_dict_rprimitive, is_set_rprimitive, is_tuple_rprimitive,
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive, ClassIR,
-    FuncIR, FuncDecl, int_rprimitive, is_optional_type, optional_value_type, all_concrete_classes
+    FuncDecl, int_rprimitive, is_optional_type, optional_value_type, all_concrete_classes
 )
 from mypyc.namegen import NameGenerator
 from mypyc.sametype import is_same_type

--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -1,11 +1,10 @@
 """Code generation for native classes and related wrappers."""
 
-import textwrap
 
 from typing import Optional, List, Tuple, Dict, Callable, Mapping, Set
 from collections import OrderedDict
 
-from mypyc.common import PREFIX, NATIVE_PREFIX, REG_PREFIX, DUNDER_PREFIX
+from mypyc.common import NATIVE_PREFIX, PREFIX, REG_PREFIX
 from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header, native_getter_name, native_setter_name
 from mypyc.emitwrapper import (
@@ -13,8 +12,8 @@ from mypyc.emitwrapper import (
     generate_bool_wrapper, generate_get_wrapper
 )
 from mypyc.ops import (
-    ClassIR, FuncIR, FuncDecl, RType, RTuple, Environment, object_rprimitive, FuncSignature,
-    VTableMethod, VTableAttr, VTableEntries,
+    ClassIR, FuncIR, FuncDecl, RType, RTuple, object_rprimitive,
+    VTableMethod, VTableEntries,
     FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
 )
 from mypyc.sametype import is_same_type

--- a/mypyc/emitfunc.py
+++ b/mypyc/emitfunc.py
@@ -1,14 +1,13 @@
 """Code generation for native function bodies."""
 
-from typing import Optional, List
 
 from mypyc.common import REG_PREFIX, NATIVE_PREFIX, STATIC_PREFIX, TYPE_PREFIX, TOP_LEVEL_NAME
 from mypyc.emit import Emitter
 from mypyc.ops import (
     FuncIR, OpVisitor, Goto, Branch, Return, Assign, LoadInt, LoadErrorValue, GetAttr, SetAttr,
     LoadStatic, InitStatic, TupleGet, TupleSet, Call, IncRef, DecRef, Box, Cast, Unbox,
-    BasicBlock, Value, Register, RType, RTuple, MethodCall, PrimitiveOp,
-    EmitterInterface, Unreachable, is_int_rprimitive, NAMESPACE_STATIC, NAMESPACE_TYPE,
+    BasicBlock, Value, RType, RTuple, MethodCall, PrimitiveOp,
+    EmitterInterface, Unreachable, NAMESPACE_STATIC, NAMESPACE_TYPE,
     RaiseStandardError, FuncDecl, ClassIR,
     FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
 )

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -4,8 +4,7 @@ from mypyc.common import PREFIX, NATIVE_PREFIX, DUNDER_PREFIX
 from mypyc.emit import Emitter
 from mypyc.ops import (
     ClassIR, FuncIR, RType, RuntimeArg,
-    is_object_rprimitive, is_int_rprimitive, is_bool_rprimitive,
-    bool_rprimitive, object_rprimitive,
+    is_object_rprimitive, is_int_rprimitive, is_bool_rprimitive, object_rprimitive,
     FUNC_STATICMETHOD,
 )
 from mypyc.namegen import NameGenerator
@@ -13,10 +12,6 @@ from mypyc.namegen import NameGenerator
 from mypy.nodes import ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2
 
 from typing import List, Optional
-
-MYPY = False
-if MYPY:
-    from typing_extensions import Final
 
 
 def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -9,14 +9,12 @@ We need to split basic blocks on each error check since branches can
 only be placed at the end of a basic block.
 """
 
-from typing import Optional, List, Dict
+from typing import List
 
 from mypyc.ops import (
-    FuncIR, BasicBlock, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
-    ERR_FALSE, RegisterOp, PrimitiveOp,
-    NO_TRACEBACK_LINE_NO,
+    FuncIR, BasicBlock, LoadErrorValue, Return, Branch, RegisterOp,
+    ERR_NEVER, ERR_MAGIC, ERR_FALSE, NO_TRACEBACK_LINE_NO,
 )
-from mypyc.ops_exc import assert_err_occured_op
 
 
 def insert_exception_handling(ir: FuncIR) -> None:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3985,7 +3985,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.add(Branch(_y_init, stop_block, main_block, Branch.IS_ERROR))
 
         # Try extracting a return value from a StopIteration and return it.
-        # If it wasn't, this rereaises the exception.
+        # If it wasn't, this reraises the exception.
         self.activate_block(stop_block)
         self.assign(result, self.primitive_op(check_stop_op, [], o.line), o.line)
         self.goto(done_block)

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -21,14 +21,13 @@ if MYPY:
     from typing import ClassVar, NoReturn
 from abc import abstractmethod
 import sys
-import traceback
 import importlib.util
 import itertools
 
 from mypy.build import Graph
 from mypy.nodes import (
-    Node, MypyFile, SymbolNode, Statement, FuncItem, FuncDef, ReturnStmt, AssignmentStmt, OpExpr,
-    IntExpr, NameExpr, LDEF, Var, IfStmt, UnaryExpr, ComparisonExpr, WhileStmt, Argument, CallExpr,
+    MypyFile, SymbolNode, Statement, FuncItem, FuncDef, ReturnStmt, AssignmentStmt, OpExpr,
+    IntExpr, NameExpr, LDEF, Var, IfStmt, UnaryExpr, ComparisonExpr, WhileStmt, CallExpr,
     IndexExpr, Block, Expression, ListExpr, ExpressionStmt, MemberExpr, ForStmt, RefExpr, Lvalue,
     BreakStmt, ContinueStmt, ConditionalExpr, OperatorAssignmentStmt, TupleExpr, ClassDef,
     TypeInfo, Import, ImportFrom, ImportAll, DictExpr, StrExpr, CastExpr, TempNode,
@@ -38,17 +37,16 @@ from mypy.nodes import (
     NamedTupleExpr, NewTypeExpr, NonlocalDecl, OverloadedFuncDef, PrintStmt, RaiseStmt,
     RevealExpr, SetExpr, SliceExpr, StarExpr, SuperExpr, TryStmt, TypeAliasExpr, TypeApplication,
     TypeVarExpr, TypedDictExpr, UnicodeExpr, WithStmt, YieldFromExpr, YieldExpr, GDEF, ARG_POS,
-    ARG_OPT, ARG_NAMED, ARG_STAR, ARG_NAMED_OPT, ARG_STAR2, is_class_var, op_methods
+    ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, is_class_var, op_methods
 )
 import mypy.nodes
 import mypy.errors
 from mypy.types import (
     Type, Instance, CallableType, NoneTyp, TupleType, UnionType, AnyType, TypeVarType, PartialType,
-    TypeType, FunctionLike, Overloaded, TypeOfAny, UninhabitedType, UnboundType, TypedDictType,
+    TypeType, Overloaded, TypeOfAny, UninhabitedType, UnboundType, TypedDictType,
     LiteralType,
 )
 from mypy.visitor import ExpressionVisitor, StatementVisitor
-from mypy.subtypes import is_named_instance
 from mypy.checkexpr import map_actuals_to_formals
 from mypy.state import strict_optional_set
 
@@ -66,15 +64,14 @@ from mypyc.ops import (
     LoadStatic, InitStatic, MethodCall, INVALID_FUNC_DEF, int_rprimitive, float_rprimitive,
     bool_rprimitive, list_rprimitive, is_list_rprimitive, dict_rprimitive, set_rprimitive,
     str_rprimitive, tuple_rprimitive, none_rprimitive, is_none_rprimitive, object_rprimitive,
-    exc_rtuple, is_tuple_rprimitive,
-    PrimitiveOp, ControlOp, LoadErrorValue, ERR_FALSE, OpDescription, RegisterOp,
+    exc_rtuple,
+    PrimitiveOp, ControlOp, LoadErrorValue, OpDescription, RegisterOp,
     is_object_rprimitive, LiteralsMap, FuncSignature, VTableAttr, VTableMethod, VTableEntries,
     NAMESPACE_TYPE, RaiseStandardError, LoadErrorValue, NO_TRACEBACK_LINE_NO, FuncDecl,
     FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD,
-    RUnion, is_optional_type, optional_value_type, is_short_int_rprimitive, all_concrete_classes
+    RUnion, is_optional_type, optional_value_type, all_concrete_classes
 )
 from mypyc.ops_primitive import binary_ops, unary_ops, func_ops, method_ops, name_ref_ops
-from mypyc.ops_int import unsafe_short_add
 from mypyc.ops_list import (
     list_append_op, list_extend_op, list_len_op, new_list_op, to_list, list_pop_last
 )
@@ -93,7 +90,7 @@ from mypyc.ops_misc import (
     ellipsis_op, method_new_op, type_is_op, type_object_op, py_calc_meta_op
 )
 from mypyc.ops_exc import (
-    no_err_occurred_op, raise_exception_op, raise_exception_with_tb_op, reraise_exception_op,
+    raise_exception_op, raise_exception_with_tb_op, reraise_exception_op,
     error_catch_op, restore_exc_info_op, exc_matches_op, get_exc_value_op,
     get_exc_info_op, keep_propagating_op,
 )

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3396,7 +3396,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             length = self.primitive_op(list_len_op, [value], value.line)
             zero = self.add(LoadInt(0))
             value = self.binary_op(length, zero, '!=', value.line)
-        elif isinstance(value.type, RInstance) and value.type.class_ir.has_method('__bool__'):
+        elif (isinstance(value.type, RInstance) and value.type.class_ir.is_ext_class
+                and value.type.class_ir.has_method('__bool__')):
             # Directly call the __bool__ method on classes that have it.
             value = self.gen_method_call(value, '__bool__', [], bool_rprimitive, value.line)
         else:

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -81,7 +81,7 @@ from mypyc.ops_dict import (
 )
 from mypyc.ops_set import new_set_op, set_add_op, set_update_op
 from mypyc.ops_misc import (
-    none_op, none_object_op, true_op, false_op, iter_op, next_op, next_raw_op,
+    none_op, none_object_op, true_op, false_op, iter_op, next_op,
     check_stop_op, send_op, yield_from_except_op,
     py_getattr_op, py_setattr_op, py_delattr_op, py_hasattr_op,
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
@@ -3996,7 +3996,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             self.primitive_op(iter_op, [self.accept(o.expr)], o.line))
 
         stop_block, main_block, done_block = BasicBlock(), BasicBlock(), BasicBlock()
-        _y_init = self.primitive_op(next_raw_op, [self.read(iter_reg)], o.line)
+        _y_init = self.primitive_op(next_op, [self.read(iter_reg)], o.line)
         self.add(Branch(_y_init, stop_block, main_block, Branch.IS_ERROR))
 
         # Try extracting a return value from a StopIteration and return it.

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3082,8 +3082,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             if decl.kind == FUNC_CLASSMETHOD:
                 vself = self.primitive_op(type_op, [vself], expr.line)
             elif self.fn_info.is_generator:
-                # self is sixth value in symtable for generator functions
-                self_targ = list(self.environment.symtable.values())[6]
+                self_targ = self.environment.get_self_targ()
                 vself = self.read(self_targ, self.fn_info.fitem.line)
             arg_values.insert(0, vself)
             arg_kinds.insert(0, ARG_POS)
@@ -3951,8 +3950,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             iter_env = iter(self.environment.indexes)
             vself = next(iter_env)  # grab first argument
             if self.fn_info.is_generator:
-                # self is sixth value in symtable
-                self_targ = list(self.environment.symtable.values())[6]
+                self_targ = self.environment.get_self_targ()
                 vself = self.read(self_targ, self.fn_info.fitem.line)
             elif not ir.is_ext_class:
                 vself = next(iter_env)  # second argument is self if non_extension class

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1252,6 +1252,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # https://github.com/python/cpython/blob/3.7/Lib/dataclasses.py#L957
         filler_doc_str = 'filler docstring for classes decorated with dataclass'
         self.add_to_non_ext_dict('__doc__', self.load_static_unicode(filler_doc_str), line)
+        self.add_to_non_ext_dict('__module__', self.load_static_unicode(self.module_name), line)
         metaclass = self.primitive_op(type_object_op, [], line)
         metaclass = self.primitive_op(py_calc_meta_op, [metaclass, self.non_ext_info.bases], line)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1749,15 +1749,15 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.enter(FuncInfo(fitem, name, class_name, self.gen_func_ns(),
                             is_nested, contains_nested, is_decorated, in_non_ext))
 
-        if self.fn_info.is_nested or self.fn_info.in_non_ext:
-            self.setup_callable_class()
-
         # Functions that contain nested functions need an environment class to store variables that
         # are free in their nested functions. Generator functions need an environment class to
         # store a variable denoting the next instruction to be executed when the __next__ function
         # is called, along with all the variables inside the function itself.
         if self.fn_info.contains_nested or self.fn_info.is_generator:
             self.setup_env_class()
+
+        if self.fn_info.is_nested or self.fn_info.in_non_ext:
+            self.setup_callable_class()
 
         if self.fn_info.is_generator:
             # Do a first-pass and generate a function that just returns a generator object.
@@ -3081,6 +3081,10 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             vself = next(iter(self.environment.indexes))  # grab first argument
             if decl.kind == FUNC_CLASSMETHOD:
                 vself = self.primitive_op(type_op, [vself], expr.line)
+            elif self.fn_info.is_generator:
+                # self is sixth value in symtable for generator functions
+                self_targ = list(self.environment.symtable.values())[6]
+                vself = self.read(self_targ, self.fn_info.fitem.line)
             arg_values.insert(0, vself)
             arg_kinds.insert(0, ARG_POS)
             arg_names.insert(0, None)
@@ -3945,7 +3949,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             ir = self.mapper.type_to_ir[o.info]
             iter_env = iter(self.environment.indexes)
             vself = next(iter_env)  # grab first argument
-            if not ir.is_ext_class:
+            if self.fn_info.is_generator:
+                # self is sixth value in symtable
+                self_targ = list(self.environment.symtable.values())[6]
+                vself = self.read(self_targ, self.fn_info.fitem.line)
+            elif not ir.is_ext_class:
                 vself = next(iter_env)  # second argument is self if non_extension class
             args = [typ, vself]
         res = self.py_call(sup_val, args, o.line)

--- a/mypyc/genops_for.py
+++ b/mypyc/genops_for.py
@@ -9,7 +9,7 @@ from typing import Union, List
 
 from mypy.nodes import Lvalue, Expression
 from mypyc.ops import (
-    Value, BasicBlock, int_rprimitive, is_short_int_rprimitive, LoadInt, RType,
+    Value, BasicBlock, is_short_int_rprimitive, LoadInt, RType,
     PrimitiveOp, Branch, Register, AssignmentTarget
 )
 from mypyc.ops_int import unsafe_short_add
@@ -58,19 +58,15 @@ class ForGenerator:
 
     def gen_condition(self) -> None:
         """Generate check for loop exit (e.g. exhaustion of iteration)."""
-        pass
 
     def begin_body(self) -> None:
         """Generate ops at the beginning of the body (if needed)."""
-        pass
 
     def gen_step(self) -> None:
         """Generate stepping to the next item (if needed)."""
-        pass
 
     def gen_cleanup(self) -> None:
         """Generate post-loop cleanup (if needed)."""
-        pass
 
 
 class ForIterable(ForGenerator):

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -912,11 +912,6 @@ static PyObject *CPyDict_FromAny(PyObject *obj) {
     }
 }
 
-static PyObject *CPyIter_Next(PyObject *iter)
-{
-    return (*iter->ob_type->tp_iternext)(iter);
-}
-
 static PyObject *CPy_FetchStopIterationValue(void)
 {
     PyObject *val = NULL;
@@ -930,7 +925,7 @@ static PyObject *CPyIter_Send(PyObject *iter, PyObject *val)
     // (This behavior is to match the PEP 380 spec for yield from.)
     _Py_IDENTIFIER(send);
     if (val == Py_None) {
-        return CPyIter_Next(iter);
+        return PyIter_Next(iter);
     } else {
         return _PyObject_CallMethodIdObjArgs(iter, &PyId_send, val, NULL);
     }

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -912,6 +912,11 @@ static PyObject *CPyDict_FromAny(PyObject *obj) {
     }
 }
 
+static PyObject *CPyIter_Next(PyObject *iter)
+{
+    return (*iter->ob_type->tp_iternext)(iter);
+}
+
 static PyObject *CPy_FetchStopIterationValue(void)
 {
     PyObject *val = NULL;
@@ -925,7 +930,7 @@ static PyObject *CPyIter_Send(PyObject *iter, PyObject *val)
     // (This behavior is to match the PEP 380 spec for yield from.)
     _Py_IDENTIFIER(send);
     if (val == Py_None) {
-        return PyIter_Next(iter);
+        return CPyIter_Next(iter);
     } else {
         return _PyObject_CallMethodIdObjArgs(iter, &PyId_send, val, NULL);
     }

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -10,17 +10,15 @@ can hold various things:
 - literals (integer literals, True, False, etc.)
 """
 
-from abc import abstractmethod, abstractproperty
-import re
+from abc import abstractmethod
 from typing import (
     List, Sequence, Dict, Generic, TypeVar, Optional, Any, NamedTuple, Tuple, Callable,
     Union, Iterable, Type, Set
 )
 from collections import OrderedDict
 
-from mypyc.common import PROPSET_PREFIX
 
-from mypy.nodes import Block, SymbolNode, Var, FuncDef, ARG_POS, ARG_OPT, ARG_NAMED_OPT
+from mypy.nodes import ARG_NAMED_OPT, ARG_OPT, ARG_POS, Block, FuncDef, SymbolNode
 
 from mypy_extensions import trait
 
@@ -1858,9 +1856,9 @@ def all_concrete_classes(class_ir: ClassIR) -> List[ClassIR]:
 
 
 # Import various modules that set up global state.
-import mypyc.ops_int
-import mypyc.ops_str
-import mypyc.ops_list
-import mypyc.ops_dict
-import mypyc.ops_tuple
-import mypyc.ops_misc
+import mypyc.ops_int  # noqa
+import mypyc.ops_str  # noqa
+import mypyc.ops_list  # noqa
+import mypyc.ops_dict  # noqa
+import mypyc.ops_tuple  # noqa
+import mypyc.ops_misc  # noqa

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -414,7 +414,7 @@ class Environment:
     def __init__(self, name: Optional[str] = None) -> None:
         self.name = name
         self.indexes = OrderedDict()  # type: Dict[Value, int]
-        self.symtable = {}  # type: Dict[SymbolNode, AssignmentTarget]
+        self.symtable = OrderedDict()  # type: OrderedDict[SymbolNode, AssignmentTarget]
         self.temp_index = 0
         self.names = {}  # type: Dict[str, int]
         self.vars_needing_init = set()  # type: Set[Value]
@@ -456,15 +456,6 @@ class Environment:
 
     def lookup(self, symbol: SymbolNode) -> AssignmentTarget:
         return self.symtable[symbol]
-
-    def get_self_targ(self) -> AssignmentTarget:
-        self_targ = None
-        for k, v in self.symtable.items():
-            if k.name() == 'self':
-                self_targ = v
-                break
-        assert self_targ is not None
-        return self_targ
 
     def add_temp(self, typ: RType, is_arg: bool = False) -> 'Register':
         assert isinstance(typ, RType)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -457,6 +457,15 @@ class Environment:
     def lookup(self, symbol: SymbolNode) -> AssignmentTarget:
         return self.symtable[symbol]
 
+    def get_self_targ(self) -> AssignmentTarget:
+        self_targ = None
+        for k, v in self.symtable.items():
+            if k.name() == 'self':
+                self_targ = v
+                break
+        assert self_targ != None
+        return self_targ
+
     def add_temp(self, typ: RType, is_arg: bool = False) -> 'Register':
         assert isinstance(typ, RType)
         reg = Register(typ, is_arg=is_arg)

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -463,7 +463,7 @@ class Environment:
             if k.name() == 'self':
                 self_targ = v
                 break
-        assert self_targ != None
+        assert self_targ is not None
         return self_targ
 
     def add_temp(self, typ: RType, is_arg: bool = False) -> 'Register':

--- a/mypyc/ops_dict.py
+++ b/mypyc/ops_dict.py
@@ -3,14 +3,13 @@
 from typing import List
 
 from mypyc.ops import (
-    EmitterInterface, PrimitiveOp,
+    EmitterInterface,
     dict_rprimitive, object_rprimitive, bool_rprimitive, int_rprimitive,
     ERR_FALSE, ERR_MAGIC, ERR_NEVER,
 )
 from mypyc.ops_primitive import (
     name_ref_op, method_op, binary_op, func_op, custom_op,
-    simple_emit, negative_int_emit,
-    call_emit, call_negative_bool_emit, call_negative_magic_emit,
+    simple_emit, negative_int_emit, call_emit, call_negative_bool_emit,
 )
 
 

--- a/mypyc/ops_exc.py
+++ b/mypyc/ops_exc.py
@@ -1,16 +1,12 @@
 """Exception-related primitive ops."""
 
-from typing import List
 
 from mypyc.ops import (
-    EmitterInterface, PrimitiveOp, none_rprimitive, bool_rprimitive, object_rprimitive,
-    void_rtype,
-    exc_rtuple,
-    ERR_NEVER, ERR_MAGIC, ERR_FALSE
+    bool_rprimitive, object_rprimitive, void_rtype, exc_rtuple,
+    ERR_NEVER, ERR_FALSE
 )
 from mypyc.ops_primitive import (
-    simple_emit, func_op, method_op, custom_op,
-    negative_int_emit,
+    simple_emit, custom_op,
 )
 
 # TODO: Making this raise conditionally is kind of hokey.

--- a/mypyc/ops_int.py
+++ b/mypyc/ops_int.py
@@ -1,9 +1,7 @@
-from typing import List
 
 from mypyc.ops import (
-    PrimitiveOp,
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive, short_int_rprimitive,
-    RType, EmitterInterface, OpDescription,
+    RType, OpDescription,
     ERR_NEVER, ERR_MAGIC,
 )
 from mypyc.ops_primitive import (

--- a/mypyc/ops_list.py
+++ b/mypyc/ops_list.py
@@ -5,7 +5,7 @@ from typing import List
 from mypyc.ops import (
     int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive, bool_rprimitive,
     ERR_MAGIC, ERR_NEVER,
-    ERR_FALSE, EmitterInterface, PrimitiveOp, Value
+    ERR_FALSE, EmitterInterface,
 )
 from mypyc.ops_primitive import (
     name_ref_op, binary_op, func_op, method_op, custom_op, simple_emit,

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -84,7 +84,6 @@ send_op = custom_op(name='send',
                     error_kind=ERR_NEVER,
                     emit=call_emit('CPyIter_Send'))
 
-
 # This is sort of unfortunate but oh well: yield_from_except performs most of the
 # error handling logic in `yield from` operations. It returns a bool and a value.
 # If the bool is true, then a StopIteration was received and we should return.

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -62,8 +62,10 @@ next_op = custom_op(name='next',
                     error_kind=ERR_NEVER,
                     emit=call_emit('PyIter_Next'))
 
-# Do a next, don't swallow StopIteration, but also don't
-# propagate an error.
+# Do a next, don't swallow StopIteration, but also don't propagate an
+# error. (N.B: This can still return NULL without an error to
+# represent an implicit StopIteration, but if StopIteration is
+# *explicitly* raised this will not swallow it.)
 # Can return NULL: see next_op.
 next_raw_op = custom_op(name='next',
                         arg_types=[object_rprimitive],
@@ -81,13 +83,6 @@ send_op = custom_op(name='send',
                     result_type=object_rprimitive,
                     error_kind=ERR_NEVER,
                     emit=call_emit('CPyIter_Send'))
-
-# An honest next. Doesn't swallow StopIteration, raises exceptions.
-func_op(name='builtins.next',
-        arg_types=[object_rprimitive],
-        result_type=object_rprimitive,
-        error_kind=ERR_MAGIC,
-        emit=call_emit('CPyIter_Next'))
 
 
 # This is sort of unfortunate but oh well: yield_from_except performs most of the
@@ -113,6 +108,7 @@ method_new_op = custom_op(name='method_new',
                           emit=call_emit('PyMethod_New'))
 
 # Check if the current exception is a StopIteration and return its value if so.
+# Treats "no exception" as StopIteration with a None value.
 # If it is a different exception, re-reraise it.
 check_stop_op = custom_op(name='check_stop_iteration',
                           arg_types=[],

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -1,10 +1,8 @@
 """Miscellaneous primitive ops."""
 
-from typing import List
 
 from mypyc.ops import (
-    EmitterInterface, PrimitiveOp, RTuple,
-    none_rprimitive, bool_rprimitive, object_rprimitive, tuple_rprimitive, str_rprimitive,
+    RTuple, none_rprimitive, bool_rprimitive, object_rprimitive, str_rprimitive,
     int_rprimitive, dict_rprimitive,
     ERR_NEVER, ERR_MAGIC, ERR_FALSE
 )

--- a/mypyc/ops_primitive.py
+++ b/mypyc/ops_primitive.py
@@ -6,10 +6,10 @@ a specific function is called with the specific positional argument
 count and argument types.
 """
 
-from typing import Dict, List, Callable, Optional
+from typing import Dict, List, Optional
 
 from mypyc.ops import (
-    OpDescription, PrimitiveOp, RType, EmitterInterface, EmitCallback, StealsDescription,
+    OpDescription, RType, EmitterInterface, EmitCallback, StealsDescription,
     short_name, bool_rprimitive
 )
 

--- a/mypyc/ops_tuple.py
+++ b/mypyc/ops_tuple.py
@@ -7,7 +7,7 @@ These are for varying-length tuples represented as Python tuple objects
 from typing import List
 
 from mypyc.ops import (
-    EmitterInterface, PrimitiveOp, tuple_rprimitive, int_rprimitive, list_rprimitive,
+    EmitterInterface, tuple_rprimitive, int_rprimitive, list_rprimitive,
     object_rprimitive, ERR_NEVER, ERR_MAGIC
 )
 from mypyc.ops_primitive import (

--- a/mypyc/prebuildvisitor.py
+++ b/mypyc/prebuildvisitor.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple, Optional
+from typing import Dict, List, Set
 
 from mypy.nodes import (
     Decorator, Expression, FuncDef, FuncItem, LambdaExpr, NameExpr, SymbolNode, Var, MemberExpr

--- a/mypyc/refcount.py
+++ b/mypyc/refcount.py
@@ -16,7 +16,7 @@ decremented before returning. An assignment to a borrowed value turns it
 into a regular, owned reference that needs to freed before return.
 """
 
-from typing import List, Dict, Tuple, Set, Iterable, Optional
+from typing import Dict, Iterable, List, Set, Tuple
 
 from mypyc.analysis import (
     get_cfg,
@@ -29,7 +29,7 @@ from mypyc.analysis import (
 )
 from mypyc.ops import (
     FuncIR, BasicBlock, Assign, RegisterOp, DecRef, IncRef, Branch, Goto, Environment,
-    Return, Op, ControlOp, RType, Value, Register, AssignmentTargetRegister
+    Op, ControlOp, Value, Register
 )
 
 

--- a/mypyc/rt_subtype.py
+++ b/mypyc/rt_subtype.py
@@ -15,11 +15,8 @@ coercion is necessary first.
 
 from mypyc.ops import (
     RType, RUnion, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor,
-    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
-    is_short_int_rprimitive,
-    is_object_rprimitive
+    is_int_rprimitive, is_short_int_rprimitive,
 )
-from mypyc.sametype import is_same_type
 from mypyc.subtype import is_subtype
 
 

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -2,7 +2,7 @@
 
 from mypyc.ops import (
     RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion,
-    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, none_rprimitive,
+    is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive,
     is_short_int_rprimitive,
     is_object_rprimitive
 )

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -12,7 +12,7 @@ from mypyc import exceptions
 from mypyc.ops import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines
+    assert_test_output,
 )
 
 files = [

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -3,7 +3,7 @@ import unittest
 from mypy.nodes import Var
 
 from mypyc.emit import Emitter, EmitterContext
-from mypyc.ops import Environment, RType, int_rprimitive, BasicBlock
+from mypyc.ops import BasicBlock, Environment, int_rprimitive
 
 
 class TestEmitter(unittest.TestCase):

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -6,7 +6,7 @@ from mypy.nodes import Var
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.ops import (
-    Environment, BasicBlock, FuncIR, RuntimeArg, RType, Goto, Return, LoadInt, Assign,
+    Environment, BasicBlock, FuncIR, RuntimeArg, Goto, Return, LoadInt, Assign,
     IncRef, DecRef, Branch, Call, Unbox, Box, RTuple, TupleGet, GetAttr, PrimitiveOp,
     RegisterOp, FuncDecl,
     ClassIR, RInstance, SetAttr, Op, Value, int_rprimitive, bool_rprimitive,

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -7,28 +7,24 @@ import subprocess
 import contextlib
 import shutil
 import sys
-from typing import List, Iterator, Optional
+from typing import Iterator, Optional
 
 from mypy import build
 from mypy.test.data import DataDrivenTestCase
-from mypy.test.config import test_temp_dir, PREFIX
+from mypy.test.config import test_temp_dir
 from mypy.errors import CompileError
 from mypy.options import Options
 
-from mypyc import genops
 from mypyc import emitmodule
 from mypyc.options import CompilerOptions
-from mypyc.test.config import prefix
 from mypyc.build import shared_lib_name
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, TESTUTIL_PATH,
     use_custom_builtins, MypycDataSuite, assert_test_output,
-    heading, show_c
+    show_c
 )
 
 from distutils.core import run_setup
-
-import pytest  # type: ignore  # no pytest in typeshed
 
 files = [
     'run-functions.test',

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -183,8 +183,7 @@ class TestRun(MypycDataSuite):
 
             proc = subprocess.Popen(['python', driver_path], stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT, env=env)
-            output, _ = proc.communicate()
-            output = output.decode('utf8')
+            output = proc.communicate()[0].decode('utf8')
             outlines = output.splitlines()
 
             show_c(cfiles)

--- a/mypyc/uninit.py
+++ b/mypyc/uninit.py
@@ -1,6 +1,6 @@
 """Insert checks for uninitialized values."""
 
-from typing import Optional, List, Dict
+from typing import List
 
 from mypyc.analysis import (
     get_cfg,
@@ -9,10 +9,8 @@ from mypyc.analysis import (
     AnalysisDict
 )
 from mypyc.ops import (
-    FuncIR, BasicBlock, LoadErrorValue, Return, Goto, Branch, ERR_NEVER, ERR_MAGIC,
+    FuncIR, BasicBlock, Branch,
     Value, RaiseStandardError, Unreachable, Environment, Register,
-    ERR_FALSE, RegisterOp, PrimitiveOp,
-    NO_TRACEBACK_LINE_NO,
 )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ exclude =
 # Things to ignore:
 #   E251: spaces around default arg value (against our style)
 #   E128: continuation line under-indented (too noisy)
-#   F401: unused identifiers (useless, as it doesn't see inside # type: comments)
 #   W601: has_key() deprecated (false positives)
 #   E701: multiple statements on one line (colon) (we use this for classes with empty body)
 #   W503: line break before binary operator
@@ -32,7 +31,7 @@ exclude =
 #   B007: Loop control variable not used within the loop body.
 #   F811: method redefinition (breaks @overload)
 #   B011: Don't use assert False
-ignore = E251,E128,F401,W601,E701,W503,E704,E402,B3,B006,B007,F811,B011
+ignore = E251,E128,W601,E701,W503,E704,E402,B3,B006,B007,F811,B011
 
 [coverage:run]
 branch = true

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -51,8 +51,10 @@ class str:
     def __gt__(self, x: str) -> bool: ...
     def __ge__(self, x: str) -> bool: ...
     def __contains__(self, item: str) -> bool: pass
+    def strip (self, item: str) -> str: pass
     def join(self, x: Iterable[str]) -> str: pass
     def format(self, *args: Any, **kwargs: Any) -> str: ...
+    def upper(self) -> str: pass
 
 class float:
     def __init__(self, x: object) -> None: pass

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -188,6 +188,7 @@ def len(o: object) -> int: pass
 def print(*object) -> None: pass
 def range(x: int, y: int = ..., z: int = ...) -> Iterator[int]: pass
 def isinstance(x: object, t: object) -> bool: pass
+def iter(i: Iterable[T]) -> Iterator[T]: pass
 @overload
 def next(i: Iterator[T]) -> T: pass
 @overload

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -100,6 +100,7 @@ assert a.c == 3
 assert a.get_a() == 1
 assert a.get_b() == 2
 assert a.get_c() == 3
+assert A.constant() == 4
 
 [case testEnum]
 from enum import Enum

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -131,6 +131,15 @@ class Person1:
     age : int
     name : str
 
+    def __bool__(self) -> bool:
+        return self.name == 'robot'
+
+def testBool(p: Person1) -> bool:
+    if p:
+        return True
+    else:
+        return False
+
 @dataclass
 class Person2:
     age : int
@@ -179,10 +188,12 @@ version = sys.version_info[:2]
 if version[0] < 3 or version[1] < 7:
     exit()
 
-from native import Person1, Person2, Person3, Person4
+from native import Person1, Person2, Person3, Person4, testBool
 i1 = Person1(age = 5, name = 'robot')
 assert i1.age == 5
 assert i1.name == 'robot'
+assert testBool(i1) == True
+assert testBool(Person1(age = 5, name = 'robo')) == False
 i2 = Person2(age = 5)
 assert i2.age == 5
 assert i2.name == 'robot'

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3757,16 +3757,37 @@ assert run_generator(basic(), [5, 50]) == ((1, 6), 50)
 assert run_generator(use_from(), [5, 50]) == ((1, 6), 50)
 
 [case testYieldFrom]
-from typing import Generator, Iterator
+from typing import Generator, Iterator, List
 
 def basic() -> Iterator[int]:
     yield from [1, 2, 3]
 
+def call_next() -> int:
+    x = []  # type: List[int]
+    return next(iter(x))
+
+def inner(b: bool) -> Generator[int, None, int]:
+    if b:
+        yield from [1, 2, 3]
+    return 10
+
+def with_return(b: bool) -> Generator[int, None, int]:
+    x = yield from inner(b)
+    for a in [1, 2]:
+        pass
+    return x
+
 [file driver.py]
-from native import basic
-from testutil import run_generator
+from native import basic, call_next, with_return
+from testutil import run_generator, assertRaises
 
 assert run_generator(basic()) == ((1, 2, 3), None)
+
+with assertRaises(StopIteration):
+    call_next()
+
+assert run_generator(with_return(True)) == ((1, 2, 3), 10)
+assert run_generator(with_return(False)) == ((), 10)
 
 [case testDecorators1]
 from typing import Generator, Callable, Iterator

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -4050,6 +4050,30 @@ with assertRaises(StopIteration):
 2
 42
 
+[case testGeneratorSuper]
+from dataclasses import dataclass
+from typing import Iterator, Callable, Any
+
+class A():
+    def testA(self) -> int:
+        return 2
+
+class B(A):
+    def testB(self) -> Iterator[int]:
+        x = super().testA()
+        while True:
+            yield x
+
+def testAsserts():
+    b = B()
+    b_gen = b.testB()
+    assert next(b_gen) == 2
+
+[file driver.py]
+from native import testAsserts
+
+testAsserts()
+
 [case testAssignModule]
 import a
 assert a.x == 20

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -4051,7 +4051,6 @@ with assertRaises(StopIteration):
 42
 
 [case testGeneratorSuper]
-from dataclasses import dataclass
 from typing import Iterator, Callable, Any
 
 class A():


### PR DESCRIPTION
This PR modifies mypyc in the following ways with the intent of getting mypyc closer to being able to compile Black (the python auto code formatter) with minimal changes to Black.

Each of the below points corresponds to a single commit with the exception of point 5.

1.) Functions generated via callable classes now have an empty __dict__ because the functools @wrap decorator assumes that functions have __dict__.  [relevant commit](https://github.com/mypyc/mypyc/pull/663/commits/4ef8c5ffbe3cbbaf3ca00d00d2e01b32766eb2c4)

2.) classmethod and staticmethod decorators now work with functions generated via the callable class mechanism [relevant commit](https://github.com/mypyc/mypyc/pull/663/commits/3a2177c9572e60745d254469d70db9af37b5e2da)

3.) custom __bool__ methods in non-extension classes are properly used when the instance is used as the branching predicate in an if statement [relevant commit](https://github.com/mypyc/mypyc/pull/663/commits/f7dfa172375170258c53857d313470aabd47cfb1)

4.) super calls in generator functions now work, because mypyc will now find the correct self variable in the generator class's environment [relevant commit](https://github.com/mypyc/mypyc/pull/663/commits/3c5df879afa95477ade61032a89acda310ea2068)
 
5.) Removal of the CPyIter_Next function as it returns NULL without setting an error code, which swallows StopIteration (this assumed all callers of the function would set the error code themselves if CPyIter_Next returned NULL). [relevant-commit-1](https://github.com/mypyc/mypyc/pull/663/commits/2a9f4deb286f7d373a761d2f1b905cbeacb4b54d) [relevant-commit-2](https://github.com/mypyc/mypyc/pull/663/commits/247ea1674aaf2f826a56434bd1ade39ed93518c5)