### PR TITLE
Allow subclassing of IndexWarning and UserWarning

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -522,9 +522,9 @@ def is_valid_multipart_property_def(prop: OverloadedFuncDef) -> bool:
 def can_subclass_builtin(builtin_base: str) -> bool:
     # BaseException and dict are special cased.
     return builtin_base in (
-        ['builtins.Exception', 'builtins.LookupError', 'builtins.IndexError',
+        ('builtins.Exception', 'builtins.LookupError', 'builtins.IndexError',
         'builtins.Warning', 'builtins.UserWarning',
-        'builtins.object', ])
+        'builtins.object', ))
 
 
 def prepare_class_def(path: str, module_name: str, cdef: ClassDef,

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -519,6 +519,14 @@ def is_valid_multipart_property_def(prop: OverloadedFuncDef) -> bool:
     return False
 
 
+def can_subclass_builtin(builtin_base: str) -> bool:
+    # BaseException and dict are special cased.
+    return builtin_base in (
+        ['builtins.Exception', 'builtins.LookupError', 'builtins.IndexError',
+        'builtins.Warning', 'builtins.UserWarning',
+        'builtins.object', ])
+
+
 def prepare_class_def(path: str, module_name: str, cdef: ClassDef,
                       errors: Errors, mapper: Mapper) -> None:
 
@@ -550,21 +558,18 @@ def prepare_class_def(path: str, module_name: str, cdef: ClassDef,
     for cls in info.mro:
         # Special case exceptions and dicts
         # XXX: How do we handle *other* things??
-        if cls.fullname() == 'builtins.Exception':
-            # don't do anything for Exception (we'll do something for BaseException)
-            pass
-        elif cls.fullname() == 'builtins.BaseException':
+        if cls.fullname() == 'builtins.BaseException':
             ir.builtin_base = 'PyBaseExceptionObject'
         elif cls.fullname() == 'builtins.dict':
             ir.builtin_base = 'PyDictObject'
-        elif cls.fullname() == 'builtins.object':
-            pass
         elif cls.fullname().startswith('builtins.'):
-            # Note that if we try to subclass a C extension class that
-            # isn't in builtins, bad things will happen and we won't
-            # catch it here! But this should catch a lot of the most
-            # common pitfalls.
-            errors.error("Inheriting from most builtin types is unimplemented", path, cdef.line)
+            if not can_subclass_builtin(cls.fullname()):
+                # Note that if we try to subclass a C extension class that
+                # isn't in builtins, bad things will happen and we won't
+                # catch it here! But this should catch a lot of the most
+                # common pitfalls.
+                errors.error("Inheriting from most builtin types is unimplemented",
+                             path, cdef.line)
 
     if ir.builtin_base:
         ir.attributes.clear()

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -162,6 +162,10 @@ class BaseException: pass
 class Exception(BaseException):
     def __init__(self, message: Optional[str] = None) -> None: pass
 
+class Warning(Exception): pass
+
+class UserWarning(Warning): pass
+
 class TypeError(Exception): pass
 
 class AttributeError(Exception): pass

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -1418,6 +1418,43 @@ out a
 out b
 wee
 
+[case testCustomException]
+from typing import List
+
+class ListOutOfBounds(IndexError):
+    pass
+
+class UserListWarning(UserWarning):
+    pass
+
+def f(l: List[int], k: int) -> int:
+    try:
+        return l[k]
+    except IndexError:
+        raise ListOutOfBounds("Ruh-roh from f!")
+
+def g(l: List[int], k: int) -> int:
+    try:
+        return f([1,2,3], 3)
+    except ListOutOfBounds:
+        raise ListOutOfBounds("Ruh-roh from g!")
+
+def k(l: List[int], k: int) -> int:
+    try:
+        return g([1,2,3], 3)
+    except IndexError:
+        raise UserListWarning("Ruh-roh from k!")
+
+def h() -> int:
+    try:
+        return k([1,2,3], 3)
+    except UserWarning:
+        return -1
+
+[file driver.py]
+from native import h
+assert h() == -1
+
 [case testWith]
 from typing import Any
 class Thing:


### PR DESCRIPTION
This PR allows for users to subclass builtins.IndexWarning and builtins.UserWarning. In general, it is easy to allow for subclassing from more Exception subclasses. To subclass from any subclass of Exception, just add the full name of the class to the list contained in can_subclass_builtin, and write tests to make sure that everything works accordingly. I have only added IndexWarning and UserWarning because it is what is needed to compile Black, but I can add others if it seems like a good idea to do at this time.