### PR TITLE
Remove fishy primitive implementation of builtins.next

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -3988,7 +3988,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         self.add(Branch(_y_init, stop_block, main_block, Branch.IS_ERROR))
 
         # Try extracting a return value from a StopIteration and return it.
-        # If it wasn't, this rereaises the exception.
+        # If it wasn't, this reraises the exception.
         self.activate_block(stop_block)
         self.assign(result, self.primitive_op(check_stop_op, [], o.line), o.line)
         self.goto(done_block)

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -64,8 +64,10 @@ next_op = custom_op(name='next',
                     error_kind=ERR_NEVER,
                     emit=call_emit('PyIter_Next'))
 
-# Do a next, don't swallow StopIteration, but also don't
-# propagate an error.
+# Do a next, don't swallow StopIteration, but also don't propagate an
+# error. (N.B: This can still return NULL without an error to
+# represent an implicit StopIteration, but if StopIteration is
+# *explicitly* raised this will not swallow it.)
 # Can return NULL: see next_op.
 next_raw_op = custom_op(name='next',
                         arg_types=[object_rprimitive],
@@ -83,13 +85,6 @@ send_op = custom_op(name='send',
                     result_type=object_rprimitive,
                     error_kind=ERR_NEVER,
                     emit=call_emit('CPyIter_Send'))
-
-# An honest next. Doesn't swallow StopIteration, raises exceptions.
-func_op(name='builtins.next',
-        arg_types=[object_rprimitive],
-        result_type=object_rprimitive,
-        error_kind=ERR_MAGIC,
-        emit=call_emit('CPyIter_Next'))
 
 
 # This is sort of unfortunate but oh well: yield_from_except performs most of the
@@ -115,6 +110,7 @@ method_new_op = custom_op(name='method_new',
                           emit=call_emit('PyMethod_New'))
 
 # Check if the current exception is a StopIteration and return its value if so.
+# Treats "no exception" as StopIteration with a None value.
 # If it is a different exception, re-reraise it.
 check_stop_op = custom_op(name='check_stop_iteration',
                           arg_types=[],

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -188,6 +188,7 @@ def len(o: object) -> int: pass
 def print(*object) -> None: pass
 def range(x: int, y: int = ..., z: int = ...) -> Iterator[int]: pass
 def isinstance(x: object, t: object) -> bool: pass
+def iter(i: Iterable[T]) -> Iterator[T]: pass
 @overload
 def next(i: Iterator[T]) -> T: pass
 @overload

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3757,16 +3757,37 @@ assert run_generator(basic(), [5, 50]) == ((1, 6), 50)
 assert run_generator(use_from(), [5, 50]) == ((1, 6), 50)
 
 [case testYieldFrom]
-from typing import Generator, Iterator
+from typing import Generator, Iterator, List
 
 def basic() -> Iterator[int]:
     yield from [1, 2, 3]
 
+def call_next() -> int:
+    x = []  # type: List[int]
+    return next(iter(x))
+
+def inner(b: bool) -> Generator[int, None, int]:
+    if b:
+        yield from [1, 2, 3]
+    return 10
+
+def with_return(b: bool) -> Generator[int, None, int]:
+    x = yield from inner(b)
+    for a in [1, 2]:
+        pass
+    return x
+
 [file driver.py]
-from native import basic
-from testutil import run_generator
+from native import basic, call_next, with_return
+from testutil import run_generator, assertRaises
 
 assert run_generator(basic()) == ((1, 2, 3), None)
+
+with assertRaises(StopIteration):
+    call_next()
+
+assert run_generator(with_return(True)) == ((1, 2, 3), 10)
+assert run_generator(with_return(False)) == ((), 10)
 
 [case testDecorators1]
 from typing import Generator, Callable, Iterator


### PR DESCRIPTION
It was wrong because `tp_iter` is allowed to return NULL without
setting StopIteration (to implicitly indicate StopIteration).
There is a bunch of subtlety surrounding this so I've also added
some more tests and comments.

This is a refinement of the fix @SanjitKal originally did in #663.