### PR TITLE
Fix generating glue for functions with positional default args

### DIFF
--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -37,7 +37,7 @@ from mypy.nodes import (
     NamedTupleExpr, NewTypeExpr, NonlocalDecl, OverloadedFuncDef, PrintStmt, RaiseStmt,
     RevealExpr, SetExpr, SliceExpr, StarExpr, SuperExpr, TryStmt, TypeAliasExpr, TypeApplication,
     TypeVarExpr, TypedDictExpr, UnicodeExpr, WithStmt, YieldFromExpr, YieldExpr, GDEF, ARG_POS,
-    ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, is_class_var, op_methods
+    ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, is_class_var, op_methods
 )
 import mypy.nodes
 import mypy.errors
@@ -627,6 +627,16 @@ def prepare_non_ext_class_def(path: str, module_name: str, cdef: ClassDef,
             else:
                 errors.error("Non-extension classes do not support overlaoded functions",
                              path, cdef.line)
+
+
+def concrete_arg_kind(kind: int) -> int:
+    """Find the concrete version of an arg kind that is being passed."""
+    if kind == ARG_OPT:
+        return ARG_POS
+    elif kind == ARG_NAMED_OPT:
+        return ARG_NAMED
+    else:
+        return kind
 
 
 class FuncInfo(object):
@@ -1593,7 +1603,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         args = [self.read(self.environment.add_local_reg(var, type, is_arg=True), line)
                 for var, type in fake_vars]
         arg_names = [arg.name for arg in rt_args]
-        arg_kinds = [arg.kind for arg in rt_args]
+        arg_kinds = [concrete_arg_kind(arg.kind) for arg in rt_args]
 
         retval = self.call(target.decl, args, arg_kinds, arg_names, line)
         retval = self.coerce(retval, sig.ret_type, line)

--- a/test-data/run-classes.test
+++ b/test-data/run-classes.test
@@ -154,7 +154,7 @@ class Person3:
 
 def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
     def f(a: Any) -> int:
-        return g(a) + 1 
+        return g(a) + 1
     return f
 
 @dataclass
@@ -888,16 +888,23 @@ class A:
         pass
     def bar(self, *, x: int = 0, y: int = 0) -> None:
         pass
+    def baz(self, x: int = 0) -> None:
+        pass
 class B(A):
     def foo(self, *, y: int = 0, x: int = 0) -> None:
         print(x, y)
     def bar(self, *, y: int = 0, x: int = 0) -> None:
+        print(x, y)
+    def baz(self, x: int = 0, *, y: int = 0) -> None:
         print(x, y)
 
 def a(x: A) -> None:
     x.foo(x=1)
     x.bar(x=1, y=2)
     x.bar(x=2, y=1)
+    x.baz()
+    x.baz(1)
+    x.baz(x=2)
 
 [file driver.py]
 from native import B, a
@@ -906,6 +913,9 @@ a(B())
 1 0
 1 2
 2 1
+0 0
+1 0
+2 0
 
 [case testMethodOverrideDefault3]
 class A:


### PR DESCRIPTION
`map_actuals_to_formals` doesn't believe in `ARG_OPT` as an actual
argument kind (which is fair, though it does believe in
`ARG_NAMED_OPT`). Collapse kinds down to their concrete versions.