### PR TITLE
Async await support

### DIFF
--- a/mypyc/emitclass.py
+++ b/mypyc/emitclass.py
@@ -9,7 +9,7 @@ from mypyc.emit import Emitter
 from mypyc.emitfunc import native_function_header, native_getter_name, native_setter_name
 from mypyc.emitwrapper import (
     generate_dunder_wrapper, generate_hash_wrapper, generate_richcompare_wrapper,
-    generate_bool_wrapper, generate_get_wrapper, generate_async_meth_wrapper,
+    generate_bool_wrapper, generate_get_wrapper,
 )
 from mypyc.ops import (
     ClassIR, FuncIR, FuncDecl, RType, RTuple, object_rprimitive,
@@ -55,9 +55,9 @@ AS_NUMBER_SLOT_DEFS = {
 }  # type: SlotTable
 
 AS_ASYNC_SLOT_DEFS = {
-    '__await__': ('am_await', generate_async_meth_wrapper),
-    '__aiter__': ('am_aiter', generate_async_meth_wrapper),
-    '__anext__': ('am_anext', generate_async_meth_wrapper),
+    '__await__': ('am_await', native_slot),
+    '__aiter__': ('am_aiter', native_slot),
+    '__anext__': ('am_anext', native_slot),
 }  # type: SlotTable
 
 SIDE_TABLES = [

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -196,6 +196,21 @@ def generate_bool_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
     return name
 
 
+def generate_async_meth_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
+    """Generates a wrapper for native  __await__, __aiter__, or __anext__ methods"""
+    name = '{}{}{}'.format(DUNDER_PREFIX, fn.name, cl.name_prefix(emitter.names))
+    emitter.emit_line('static PyObject *{name}(PyObject *self) {{'.format(
+        name=name
+    ))
+    emitter.emit_line('{}val = {}{}(self);'.format(emitter.ctype_spaced(fn.ret_type),
+                                                   NATIVE_PREFIX,
+                                                   fn.cname(emitter.names)))
+    emitter.emit_line('return val;')
+    emitter.emit_line('}')
+
+    return name
+
+
 def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
                           optional_args: Optional[List[RuntimeArg]] = None,
                           arg_names: Optional[List[str]] = None,

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -196,21 +196,6 @@ def generate_bool_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
     return name
 
 
-def generate_async_meth_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
-    """Generates a wrapper for native  __await__, __aiter__, or __anext__ methods"""
-    name = '{}{}{}'.format(DUNDER_PREFIX, fn.name, cl.name_prefix(emitter.names))
-    emitter.emit_line('static PyObject *{name}(PyObject *self) {{'.format(
-        name=name
-    ))
-    emitter.emit_line('{}val = {}{}(self);'.format(emitter.ctype_spaced(fn.ret_type),
-                                                   NATIVE_PREFIX,
-                                                   fn.cname(emitter.names)))
-    emitter.emit_line('return val;')
-    emitter.emit_line('}')
-
-    return name
-
-
 def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
                           optional_args: Optional[List[RuntimeArg]] = None,
                           arg_names: Optional[List[str]] = None,

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -82,7 +82,7 @@ from mypyc.ops_dict import (
 from mypyc.ops_set import new_set_op, set_add_op, set_update_op
 from mypyc.ops_misc import (
     none_op, none_object_op, true_op, false_op, iter_op, next_op, next_raw_op,
-    check_stop_op, send_op, yield_from_except_op,
+    check_stop_op, send_op, yield_from_except_op, coro_op,
     py_getattr_op, py_setattr_op, py_delattr_op, py_hasattr_op,
     py_call_op, py_call_with_kwargs_op, py_method_call_op,
     fast_isinstance_op, bool_op, new_slice_op,
@@ -4009,10 +4009,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         if isinstance(o, YieldFromExpr):
             iter_val = self.primitive_op(iter_op, [self.accept(o.expr)], o.line)
         else:
-            # If the object is a coroutine, call its' await method to get the iterator
-            iter_val = self.gen_method_call(self.accept(o.expr), '__await__', [],
-                                            object_rprimitive,
-                                            o.line)
+            iter_val = self.primitive_op(coro_op, [self.accept(o.expr)], o.line)
 
         iter_reg = self.maybe_spill_assignable(iter_val)
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -521,7 +521,7 @@ def can_subclass_builtin(builtin_base: str) -> bool:
     # BaseException and dict are special cased.
     return builtin_base in (
         ('builtins.Exception', 'builtins.LookupError', 'builtins.IndexError',
-        'builtins.Warning', 'builtins.UserWarning',
+        'builtins.Warning', 'builtins.UserWarning', 'builtins.ValueError',
         'builtins.object', ))
 
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -941,15 +941,11 @@ static PyObject *CPy_GetCoro(PyObject *obj)
     // If the type has an __await__ method, call it,
     // otherwise, fallback to calling __iter__.
     PyAsyncMethods* async_struct = obj->ob_type->tp_as_async;
-    if (async_struct != NULL) {
-        if (async_struct->am_await != NULL) {
-            return (async_struct->am_await)(obj);
-        }
-        else {
-            return PyObject_GetIter(obj);
-        }
-    }
-    else {
+    if (async_struct != NULL && async_struct->am_await != NULL) {
+        return (async_struct->am_await)(obj);
+    } else {
+        // TODO: We should check that the type is a generator decorated with
+        // asyncio.coroutine
         return PyObject_GetIter(obj);
     }
 }

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -936,6 +936,24 @@ static PyObject *CPyIter_Send(PyObject *iter, PyObject *val)
     }
 }
 
+static PyObject *CPy_GetCoro(PyObject *obj)
+{
+    // If the type has an __await__ method, call it,
+    // otherwise, fallback to calling __iter__.
+    PyAsyncMethods* async_struct = obj->ob_type->tp_as_async;
+    if (async_struct != NULL) {
+        if (async_struct->am_await != NULL) {
+            return (async_struct->am_await)(obj);
+        }
+        else {
+            return PyObject_GetIter(obj);
+        }
+    }
+    else {
+        return PyObject_GetIter(obj);
+    }
+}
+
 // mypy lets ints silently coerce to floats, so a mypyc runtime float
 // might be an int also
 static inline bool CPyFloat_Check(PyObject *o) {

--- a/mypyc/ops_misc.py
+++ b/mypyc/ops_misc.py
@@ -54,6 +54,12 @@ iter_op = func_op(name='builtins.iter',
                   error_kind=ERR_MAGIC,
                   emit=call_emit('PyObject_GetIter'))
 
+coro_op = custom_op(name='get_coroutine_obj',
+                    arg_types=[object_rprimitive],
+                    result_type=object_rprimitive,
+                    error_kind=ERR_MAGIC,
+                    emit=call_emit('CPy_GetCoro'))
+
 # Although the error_kind is set to be ERR_NEVER, this can actually
 # return NULL, and thus it must be checked using Branch.IS_ERROR.
 next_op = custom_op(name='next',

--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -162,6 +162,3 @@ a_str = " ".join(str(i) for i in range(10))
 wtvr = next(i for i in range(10) if i == 5)
 
 d1 = {1: 2}
-
-async def aio(x: Any) -> Any:  # E: async functions are unimplemented
-    await x  # E: await is unimplemented

--- a/test-data/fixtures/ir.py
+++ b/test-data/fixtures/ir.py
@@ -86,6 +86,7 @@ class tuple(Generic[T_co], Sequence[T_co], Iterable[T_co]):
     def __getitem__(self, i: int) -> T_co: pass
     def __len__(self) -> int: pass
     def __iter__(self) -> Iterator[T_co]: ...
+    def __contains__(self, item: object) -> int: ...
 
 class function: pass
 
@@ -101,6 +102,7 @@ class list(Generic[T], Sequence[T], Iterable[T]):
     def __rmul__(self, i: int) -> List[T]: pass
     def __iter__(self) -> Iterator[T]: pass
     def __len__(self) -> int: pass
+    def __contains__(self, item: object) -> int: ...
     def append(self, x: T) -> None: pass
     def pop(self, i: int = -1) -> T: pass
     def count(self, T) -> int: pass
@@ -118,7 +120,7 @@ class dict(Mapping[K, V]):
     def __getitem__(self, key: K) -> V: pass
     def __setitem__(self, k: K, v: V) -> None: pass
     def __delitem__(self, k: K) -> None: pass
-    def __contains__(self, item: object) -> bool: pass
+    def __contains__(self, item: object) -> int: pass
     def __iter__(self) -> Iterator[K]: pass
     def __len__(self) -> int: pass
     @overload

--- a/test-data/fixtures/typing-full.pyi
+++ b/test-data/fixtures/typing-full.pyi
@@ -1,0 +1,164 @@
+# More complete stub for typing module.
+#
+# Use [typing fixtures/typing-full.pyi] to use this instead of lib-stub/typing.pyi
+# in a particular test case.
+#
+# Many of the definitions have special handling in the type checker, so they
+# can just be initialized to anything.
+
+from abc import abstractmethod, ABCMeta
+
+class GenericMeta(type): pass
+
+cast = 0
+overload = 0
+Any = 0
+Union = 0
+Optional = 0
+TypeVar = 0
+Generic = 0
+Protocol = 0
+Tuple = 0
+Callable = 0
+_promote = 0
+NamedTuple = 0
+Type = 0
+no_type_check = 0
+ClassVar = 0
+Final = 0
+Literal = 0
+TypedDict = 0
+NoReturn = 0
+NewType = 0
+
+T = TypeVar('T')
+T_co = TypeVar('T_co', covariant=True)
+T_contra = TypeVar('T_contra', contravariant=True)
+U = TypeVar('U')
+V = TypeVar('V')
+S = TypeVar('S')
+
+# Note: definitions below are different from typeshed, variances are declared
+# to silence the protocol variance checks. Maybe it is better to use type: ignore?
+
+@runtime_checkable
+class Container(Protocol[T_co]):
+    @abstractmethod
+    # Use int because bool isn't in the default test builtins
+    def __contains__(self, arg: object) -> int: pass
+
+@runtime_checkable
+class Sized(Protocol):
+    @abstractmethod
+    def __len__(self) -> int: pass
+
+@runtime_checkable
+class Iterable(Protocol[T_co]):
+    @abstractmethod
+    def __iter__(self) -> 'Iterator[T_co]': pass
+
+@runtime_checkable
+class Iterator(Iterable[T_co], Protocol):
+    @abstractmethod
+    def __next__(self) -> T_co: pass
+
+class Generator(Iterator[T], Generic[T, U, V]):
+    @abstractmethod
+    def send(self, value: U) -> T: pass
+
+    @abstractmethod
+    def throw(self, typ: Any, val: Any=None, tb: Any=None) -> None: pass
+
+    @abstractmethod
+    def close(self) -> None: pass
+
+    @abstractmethod
+    def __iter__(self) -> 'Generator[T, U, V]': pass
+
+class AsyncGenerator(AsyncIterator[T], Generic[T, U]):
+    @abstractmethod
+    def __anext__(self) -> Awaitable[T]: pass
+
+    @abstractmethod
+    def asend(self, value: U) -> Awaitable[T]: pass
+
+    @abstractmethod
+    def athrow(self, typ: Any, val: Any=None, tb: Any=None) -> Awaitable[T]: pass
+
+    @abstractmethod
+    def aclose(self) -> Awaitable[T]: pass
+
+    @abstractmethod
+    def __aiter__(self) -> 'AsyncGenerator[T, U]': pass
+
+@runtime_checkable
+class Awaitable(Protocol[T]):
+    @abstractmethod
+    def __await__(self) -> Generator[Any, Any, T]: pass
+
+class AwaitableGenerator(Generator[T, U, V], Awaitable[V], Generic[T, U, V, S], metaclass=ABCMeta):
+    pass
+
+class Coroutine(Awaitable[V], Generic[T, U, V]):
+    @abstractmethod
+    def send(self, value: U) -> T: pass
+
+    @abstractmethod
+    def throw(self, typ: Any, val: Any=None, tb: Any=None) -> None: pass
+
+    @abstractmethod
+    def close(self) -> None: pass
+
+@runtime_checkable
+class AsyncIterable(Protocol[T]):
+    @abstractmethod
+    def __aiter__(self) -> 'AsyncIterator[T]': pass
+
+@runtime_checkable
+class AsyncIterator(AsyncIterable[T], Protocol):
+    def __aiter__(self) -> 'AsyncIterator[T]': return self
+    @abstractmethod
+    def __anext__(self) -> Awaitable[T]: pass
+
+class Sequence(Iterable[T_co], Container[T_co]):
+    @abstractmethod
+    def __getitem__(self, n: Any) -> T_co: pass
+
+class Mapping(Iterable[T], Generic[T, T_co], metaclass=ABCMeta):
+    def __getitem__(self, key: T) -> T_co: pass
+    @overload
+    def get(self, k: T) -> Optional[T_co]: pass
+    @overload
+    def get(self, k: T, default: Union[T_co, V]) -> Union[T_co, V]: pass
+    def values(self) -> Iterable[T_co]: pass  # Approximate return type
+    def __len__(self) -> int: ...
+    def __contains__(self, arg: object) -> int: pass
+
+class MutableMapping(Mapping[T, U], metaclass=ABCMeta):
+    def __setitem__(self, k: T, v: U) -> None: pass
+
+class SupportsInt(Protocol):
+    def __int__(self) -> int: pass
+
+def runtime_checkable(cls: T) -> T:
+    return cls
+
+class ContextManager(Generic[T]):
+    def __enter__(self) -> T: pass
+    # Use Any because not all the precise types are in the fixtures.
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any: pass
+
+TYPE_CHECKING = 1
+
+# Fallback type for all typed dicts (does not exist at runtime).
+class _TypedDict(Mapping[str, object]):
+    # Needed to make this class non-abstract. It is explicitly declared abstract in
+    # typeshed, but we don't want to import abc here, as it would slow down the tests.
+    def __iter__(self) -> Iterator[str]: ...
+    def copy(self: T) -> T: ...
+    # Using NoReturn so that only calls using the plugin hook can go through.
+    def setdefault(self, k: NoReturn, default: object) -> object: ...
+    # Mypy expects that 'default' has a type variable type.
+    def pop(self, k: NoReturn, default: T = ...) -> object: ...
+    def update(self: T, __m: T) -> None: ...
+    def __delitem__(self, k: NoReturn) -> None: ...

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -325,6 +325,7 @@ from native import f
 import asyncio
 loop = asyncio.get_event_loop()
 result = loop.run_until_complete(f())
+assert result == 1
 
 [case testRecursiveFibonacci]
 def fib(n: int) -> int:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -303,8 +303,6 @@ for k in range(12):
 
 [case testAsync]
 import asyncio
-import asyncio.tasks
-import asyncio.events
 
 async def h() -> int:
     return 1

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -301,6 +301,30 @@ for k in range(12):
     assert next(gen) == k % 4
 [out]
 
+[case testAsync]
+import asyncio
+import asyncio.runners
+import asyncio.tasks
+
+async def h() -> int:
+    return 1
+
+async def g() -> int:
+    await asyncio.sleep(0.01)
+    return await h()
+
+async def f() -> int:
+    return await g()
+
+assert asyncio.run(f()) == 1
+
+[typing fixtures/typing-full.pyi]
+
+[file driver.py]
+from native import f
+import asyncio
+assert asyncio.run(f()) == 1
+
 [case testRecursiveFibonacci]
 def fib(n: int) -> int:
     if n <= 1:

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -303,8 +303,8 @@ for k in range(12):
 
 [case testAsync]
 import asyncio
-import asyncio.runners
 import asyncio.tasks
+import asyncio.events
 
 async def h() -> int:
     return 1
@@ -316,14 +316,17 @@ async def g() -> int:
 async def f() -> int:
     return await g()
 
-assert asyncio.run(f()) == 1
+loop = asyncio.get_event_loop()
+result = loop.run_until_complete(f())
+assert result == 1
 
 [typing fixtures/typing-full.pyi]
 
 [file driver.py]
 from native import f
 import asyncio
-assert asyncio.run(f()) == 1
+loop = asyncio.get_event_loop()
+result = loop.run_until_complete(f())
 
 [case testRecursiveFibonacci]
 def fib(n: int) -> int:


### PR DESCRIPTION
This PR introduces support for async declarations on functions, and await statements. Functions with an async declaration are compiled in a manner almost identical to generator functions, with the exception that the PyTypeObject representing the async function has it's tp_as_async slot filled with a PyAsyncMethods struct, whose .am_await field is filled with a __await__ function which does the same thing as the __iter__ in the generator class. Mypyc treats await statements almost identically as yield_from statements with the exception that in order to get the iterator from the coroutine object, the __await__ method is called on the object instead of the __iter__ method. This allows await statements to work with asyncio builtin coroutine objects.