### PR TITLE
Use a function call for doing decrefs instead of a macro

### DIFF
--- a/mypyc/emit.py
+++ b/mypyc/emit.py
@@ -256,7 +256,7 @@ class Emitter:
             for i, item_type in enumerate(rtype.types):
                 self.emit_dec_ref('{}.f{}'.format(dest, i), item_type, is_xdec)
         elif not rtype.is_unboxed:
-            self.emit_line('CPy_%sDECREF(%s);' % (x, dest))
+            self.emit_line('CPy_%sDecRef(%s);' % (x, dest))
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
     def pretty_name(self, typ: RType) -> str:

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -16,6 +16,21 @@ extern "C" {
 } // why isn't emacs smart enough to not indent this
 #endif
 
+/* We use intentionally non-inlined decrefs since it pretty
+ * substantially speeds up compile time while only causing a ~1%
+ * performance degradation. We have our own copies both to avoid the
+ * null check in Py_DecRef and to avoid making an indirect PIC
+ * call. */
+CPy_NOINLINE
+static void CPy_DecRef(PyObject *p) {
+    CPy_DECREF(p);
+}
+
+CPy_NOINLINE
+static void CPy_XDecRef(PyObject *p) {
+    CPy_XDECREF(p);
+}
+
 // Naming conventions:
 //
 // Tagged: tagged int
@@ -369,19 +384,22 @@ static Py_ssize_t CPyTagged_AsSsize_t(CPyTagged x) {
     }
 }
 
-static inline void CPyTagged_IncRef(CPyTagged x) {
+CPy_NOINLINE
+static void CPyTagged_IncRef(CPyTagged x) {
     if (CPyTagged_CheckLong(x)) {
         Py_INCREF(CPyTagged_LongAsObject(x));
     }
 }
 
-static inline void CPyTagged_DecRef(CPyTagged x) {
+CPy_NOINLINE
+static void CPyTagged_DecRef(CPyTagged x) {
     if (CPyTagged_CheckLong(x)) {
         Py_DECREF(CPyTagged_LongAsObject(x));
     }
 }
 
-static inline void CPyTagged_XDecRef(CPyTagged x) {
+CPy_NOINLINE
+static void CPyTagged_XDecRef(CPyTagged x) {
     if (CPyTagged_CheckLong(x)) {
         Py_XDECREF(CPyTagged_LongAsObject(x));
     }

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -15,6 +15,14 @@
 #define CPy_Unreachable() abort()
 #endif
 
+#if defined(__clang__) || defined(__GNUC__)
+#define CPy_NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define CPy_NOINLINE __declspec(noinline)
+#else
+#define CPy_NOINLINE
+#endif
+
 // INCREF and DECREF that assert the pointer is not NULL.
 // asserts are disabled in release builds so there shouldn't be a perf hit.
 // I'm honestly kind of surprised that this isn't done by default.


### PR DESCRIPTION
When compiling mypy, this speeds up compile time with clang by 25%,
decreases code size by 7%, and slows a self check down by 1%.

Closes #592.