### PR TITLE
Implement real support for default arguments

### DIFF
--- a/test-data/commandline.test
+++ b/test-data/commandline.test
@@ -148,9 +148,6 @@ class Concrete2:
 class Trait2(Concrete2):
     pass
 
-def warning(x: List[int] = []) -> None:  # W: Unsupported default argument value
-    pass
-
 class Nope(Trait1, Concrete2):  # E: Non-trait bases must appear first in parent list  # E: Non-trait MRO must be linear
     pass
 

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -635,7 +635,7 @@ with assertRaises(NameError):
 lol
 
 [case testFunctionCallWithDefaultArgs]
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Callable, Any
 def f(x: int, y: int = 3, s: str = "test", z: object = 5) -> Tuple[int, str]:
     def inner() -> int:
         return x + y
@@ -645,8 +645,23 @@ def g() -> None:
     assert f(s = "123", x = -2) == (1, "123")
 def h(a: Optional[object] = None, b: Optional[str] = None) -> Tuple[object, Optional[str]]:
     return (a, b)
+
+def same(x: object = object()) -> object:
+    return x
+
+a_lambda: Callable[..., Any] = lambda n=20: n
+
+def nested_funcs(n: int) -> List[Callable[..., Any]]:
+    ls: List[Callable[..., Any]] = []
+    for i in range(n):
+        def f(i: int = i) -> int:
+            return i
+        ls.append(f)
+    return ls
+
+
 [file driver.py]
-from native import f, g, h
+from native import f, g, h, same, nested_funcs, a_lambda
 g()
 assert f(2) == (5, "test")
 assert f(s = "123", x = -2) == (1, "123")
@@ -654,6 +669,12 @@ assert h() == (None, None)
 assert h(10) == (10, None)
 assert h(b='a') == (None, 'a')
 assert h(10, 'a') == (10, 'a')
+assert same() == same()
+
+assert [f() for f in nested_funcs(10)] == list(range(10))
+
+assert a_lambda(10) == 10
+assert a_lambda() == 20
 
 [case testMethodCallWithDefaultArgs]
 from typing import Tuple, List


### PR DESCRIPTION
Compute the defaults at function creation time and store them in
globals (for toplevel functions) or in the function object (for nested
functions).

Fixes #336.

No tests for lambdas yet because they are broken due to a mypy bug
I've sent a fix up for (https://github.com/python/mypy/pull/7306).
(Also fix a silly lambda bug where defaults weren't supported I came
across while testing.)