### PR TITLE
Improve tracebacks

### DIFF
--- a/mypyc/emitmodule.py
+++ b/mypyc/emitmodule.py
@@ -160,7 +160,8 @@ class ModuleGenerator:
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
                 if fn.name != TOP_LEVEL_NAME:
                     emitter.emit_line()
-                    generate_wrapper_function(fn, emitter)
+                    generate_wrapper_function(
+                        fn, emitter, self.source_paths[module_name], module_name)
 
             if multi_file:
                 name = ('__native_{}.c'.format(emitter.names.private_name(module_name)))

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -47,6 +47,11 @@ def generate_wrapper_function(fn: FuncIR,
     """
     emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
 
+    # If we hit an error while processing arguments, then we emit a
+    # traceback frame to make it possible to debug where it happened.
+    # Unlike traceback frames added for exceptions seen in IR, we do this
+    # even if there is no `traceback_name`. This is because the error will
+    # have originated here and so we need it in the traceback.
     globals_static = emitter.static_name('globals', module_name)
     traceback_code = 'CPy_AddTraceback("%s", "%s", %d, %s);' % (
         source_path.replace("\\", "\\\\"),

--- a/mypyc/emitwrapper.py
+++ b/mypyc/emitwrapper.py
@@ -36,13 +36,23 @@ def make_format_string(func_name: str, groups: List[List[RuntimeArg]]) -> str:
     return '{}:{}'.format(main_format, func_name)
 
 
-def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
+def generate_wrapper_function(fn: FuncIR,
+                              emitter: Emitter,
+                              source_path: str,
+                              module_name: str) -> None:
     """Generates a CPython-compatible wrapper function for a native function.
 
     In particular, this handles unboxing the arguments, calling the native function, and
     then boxing the return value.
     """
     emitter.emit_line('{} {{'.format(wrapper_function_header(fn, emitter.names)))
+
+    globals_static = emitter.static_name('globals', module_name)
+    traceback_code = 'CPy_AddTraceback("%s", "%s", %d, %s);' % (
+        source_path.replace("\\", "\\\\"),
+        fn.traceback_name or fn.name,
+        fn.line,
+        globals_static)
 
     # If fn is a method, then the first argument is a self param
     real_args = list(fn.args)
@@ -77,7 +87,8 @@ def generate_wrapper_function(fn: FuncIR, emitter: Emitter) -> None:
         'return NULL;',
         '}')
     generate_wrapper_core(fn, emitter, groups[ARG_OPT] + groups[ARG_NAMED_OPT],
-                          cleanups=cleanups)
+                          cleanups=cleanups,
+                          traceback_code=traceback_code)
 
     emitter.emit_line('}')
 
@@ -199,7 +210,8 @@ def generate_bool_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
 def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
                           optional_args: Optional[List[RuntimeArg]] = None,
                           arg_names: Optional[List[str]] = None,
-                          cleanups: Optional[List[str]] = None) -> None:
+                          cleanups: Optional[List[str]] = None,
+                          traceback_code: Optional[str] = None) -> None:
     """Generates the core part of a wrapper function for a native function.
     This expects each argument as a PyObject * named obj_{arg} as a precondition.
     It converts the PyObject *s to the necessary types, checking and unboxing if necessary,
@@ -208,7 +220,8 @@ def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
 
     optional_args = optional_args or []
     cleanups = cleanups or []
-    error_code = 'return NULL;' if not cleanups else 'goto fail;'
+    use_goto = bool(cleanups or traceback_code)
+    error_code = 'return NULL;' if not use_goto else 'goto fail;'
 
     arg_names = arg_names or [arg.name for arg in fn.args]
     for arg_name, arg in zip(arg_names, fn.args):
@@ -216,18 +229,18 @@ def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
         typ = arg.type if arg.kind not in (ARG_STAR, ARG_STAR2) else object_rprimitive
         generate_arg_check(arg_name, typ, emitter, error_code, arg in optional_args)
     native_args = ', '.join('arg_{}'.format(arg) for arg in arg_names)
-    if fn.ret_type.is_unboxed or cleanups:
+    if fn.ret_type.is_unboxed or use_goto:
         # TODO: The Py_RETURN macros return the correct PyObject * with reference count handling.
         #       Are they relevant?
         emitter.emit_line('{}retval = {}{}({});'.format(emitter.ctype_spaced(fn.ret_type),
                                                         NATIVE_PREFIX,
                                                         fn.cname(emitter.names),
                                                         native_args))
+        emitter.emit_lines(*cleanups)
         if fn.ret_type.is_unboxed:
-            emitter.emit_error_check('retval', fn.ret_type, error_code)
+            emitter.emit_error_check('retval', fn.ret_type, 'return NULL;')
             emitter.emit_box('retval', 'retbox', fn.ret_type, declare_dest=True)
 
-        emitter.emit_lines(*cleanups)
         emitter.emit_line('return {};'.format('retbox' if fn.ret_type.is_unboxed else 'retval'))
     else:
         emitter.emit_line('return {}{}({});'.format(NATIVE_PREFIX,
@@ -235,9 +248,11 @@ def generate_wrapper_core(fn: FuncIR, emitter: Emitter,
                                                     native_args))
         # TODO: Tracebacks?
 
-    if cleanups:
+    if use_goto:
         emitter.emit_label('fail')
         emitter.emit_lines(*cleanups)
+        if traceback_code:
+            emitter.emit_lines(traceback_code)
         emitter.emit_lines('return NULL;')
 
 

--- a/mypyc/exceptions.py
+++ b/mypyc/exceptions.py
@@ -43,7 +43,7 @@ def add_handler_block(ir: FuncIR) -> BasicBlock:
 
 def split_blocks_at_errors(blocks: List[BasicBlock],
                            default_error_handler: BasicBlock,
-                           func: Optional[str]) -> List[BasicBlock]:
+                           func_name: Optional[str]) -> List[BasicBlock]:
     new_blocks = []  # type: List[BasicBlock]
 
     # First split blocks on ops that may raise.
@@ -86,8 +86,8 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                                 op=variant,
                                 line=op.line)
                 branch.negated = negated
-                if op.line != NO_TRACEBACK_LINE_NO and func:
-                    branch.traceback_entry = (func, op.line)
+                if op.line != NO_TRACEBACK_LINE_NO and func_name is not None:
+                    branch.traceback_entry = (func_name, op.line)
                 cur_block.ops.append(branch)
                 cur_block = new_block
 

--- a/mypyc/genops.py
+++ b/mypyc/genops.py
@@ -1076,7 +1076,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         # Generate special function representing module top level.
         blocks, env, ret_type, _ = self.leave()
         sig = FuncSignature([], none_rprimitive)
-        func_ir = FuncIR(FuncDecl(TOP_LEVEL_NAME, None, self.module_name, sig), blocks, env)
+        func_ir = FuncIR(FuncDecl(TOP_LEVEL_NAME, None, self.module_name, sig), blocks, env,
+                         traceback_name="<module>")
         self.functions.append(func_ir)
 
     def handle_ext_method(self, cdef: ClassDef, fdef: FuncDef) -> None:
@@ -1932,9 +1933,11 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
             if fn_info.is_decorated:
                 class_name = None if cdef is None else cdef.name
                 func_decl = FuncDecl(fn_info.name, class_name, self.module_name, sig)
-                func_ir = FuncIR(func_decl, blocks, env)
+                func_ir = FuncIR(func_decl, blocks, env, fn_info.fitem.line,
+                                 traceback_name=fn_info.fitem.name())
             else:
-                func_ir = FuncIR(self.mapper.func_to_decl[fn_info.fitem], blocks, env)
+                func_ir = FuncIR(self.mapper.func_to_decl[fn_info.fitem], blocks, env,
+                                 fn_info.fitem.line, traceback_name=fn_info.fitem.name())
         return (func_ir, func_reg)
 
     def load_decorated_func(self, fdef: FuncDef, orig_func_reg: Value) -> Value:
@@ -3228,7 +3231,7 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                 return target
 
         # Fall back to Python method call
-        return self.py_method_call(base, name, arg_values, base.line, arg_kinds, arg_names)
+        return self.py_method_call(base, name, arg_values, line, arg_kinds, arg_names)
 
     def union_method_call(self,
                           base: Value,
@@ -4807,7 +4810,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
         """
         sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),) + sig.args, sig.ret_type)
         call_fn_decl = FuncDecl('__call__', fn_info.callable_class.ir.name, self.module_name, sig)
-        call_fn_ir = FuncIR(call_fn_decl, blocks, env)
+        call_fn_ir = FuncIR(call_fn_decl, blocks, env,
+                            fn_info.fitem.line, traceback_name=fn_info.fitem.name())
         fn_info.callable_class.ir.methods['__call__'] = call_fn_ir
         return call_fn_ir
 
@@ -4956,7 +4960,8 @@ class IRBuilder(ExpressionVisitor[Value], StatementVisitor[None]):
                              ), sig.ret_type)
         helper_fn_decl = FuncDecl('__mypyc_generator_helper__', fn_info.generator_class.ir.name,
                                   self.module_name, sig)
-        helper_fn_ir = FuncIR(helper_fn_decl, blocks, env)
+        helper_fn_ir = FuncIR(helper_fn_decl, blocks, env,
+                              fn_info.fitem.line, traceback_name=fn_info.fitem.name())
         fn_info.generator_class.ir.methods['__mypyc_generator_helper__'] = helper_fn_ir
         self.functions.append(helper_fn_ir)
         return helper_fn_decl

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1428,10 +1428,14 @@ class FuncIR:
     def __init__(self,
                  decl: FuncDecl,
                  blocks: List[BasicBlock],
-                 env: Environment) -> None:
+                 env: Environment,
+                 line: int = -1,
+                 traceback_name: Optional[str] = None) -> None:
         self.decl = decl
         self.blocks = blocks
         self.env = env
+        self.traceback_name = traceback_name
+        self.line = line
 
     @property
     def args(self) -> Sequence[RuntimeArg]:

--- a/mypyc/ops.py
+++ b/mypyc/ops.py
@@ -1434,8 +1434,11 @@ class FuncIR:
         self.decl = decl
         self.blocks = blocks
         self.env = env
-        self.traceback_name = traceback_name
         self.line = line
+        # The name that should be displayed for tracebacks that
+        # include this function. Function will be omitted from
+        # tracebacks if None.
+        self.traceback_name = traceback_name
 
     @property
     def args(self) -> Sequence[RuntimeArg]:

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -50,8 +50,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.context = EmitterContext(['mod'])
         self.emitter = Emitter(self.context, self.env)
         self.declarations = Emitter(self.context, self.env)
-        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'func', 'prog.py',
-                                              'prog')
+        self.visitor = FunctionEmitterVisitor(self.emitter, self.declarations, 'prog.py', 'prog')
 
     def test_goto(self) -> None:
         self.assert_emit(Goto(BasicBlock(2)),

--- a/test-data/run.test
+++ b/test-data/run.test
@@ -3808,21 +3808,21 @@ with ctx_manager() as c:
     raise Exception('exception')
 
 [out]
-  File "native.py", line 10, in __mypyc_generator_helper__
+  File "native.py", line 10, in generator
     yield 3
-  File "native.py", line 9, in __mypyc_generator_helper__
+  File "native.py", line 9, in generator
     yield 2
-  File "native.py", line 8, in __mypyc_generator_helper__
+  File "native.py", line 8, in generator
     yield 1
   File "driver.py", line 31, in <module>
     raise Exception
-  File "native.py", line 10, in __mypyc_generator_helper__
+  File "native.py", line 10, in generator
     yield 3
-  File "native.py", line 30, in __mypyc_generator_helper__
+  File "native.py", line 30, in wrapper
     return (yield from x)
-  File "native.py", line 9, in __mypyc_generator_helper__
+  File "native.py", line 9, in generator
     yield 2
-  File "native.py", line 30, in __mypyc_generator_helper__
+  File "native.py", line 30, in wrapper
     return (yield from x)
 caught exception without value
 caught exception with value some string


### PR DESCRIPTION
 * Use "logical" function names in traceback rather than the "real"
   function name. (For example, in a nested function, use the function
   name instead of `__call__.`)
 * Omit glue and helper functions from tracebacks. (This is
   implemented by skipping tracebacks for functions that don't have a
   "logical" name.)

Closes #428 
Closes #614